### PR TITLE
fix: R-35 gate item, missing R-03, and the contrast table

### DIFF
--- a/antislop-human.md
+++ b/antislop-human.md
@@ -73,7 +73,7 @@ The script exists so agents stop hallucinating AA. It takes two hex colors and p
 | White on #999999 | 2.85 | Fail | Fail |
 | #555555 on black | 2.82 | Fail | Fail |
 
-Ratios are given to two decimals because rounding hides failures: #777777 on white is 4.48, which fails the 4.5 bar, but reads as a pass once it is rounded to 4.5. `python scripts/contrast-check.py --selftest` asserts every row above, so the table and the script cannot drift apart.
+Ratios are given to two decimals because rounding hides failures: #777777 on white is 4.48, which fails the 4.5 bar, but reads as a pass once it is rounded to 4.5. `python scripts/contrast-check.py --selftest` reads this table, recomputes every row from the formula and checks both verdict columns, so a wrong number here fails the check.
 
 Read the table as a sanity check, not as a substitute. Any pairing not listed, or anything near a threshold, goes through the formula or the script.
 

--- a/antislop-human.md
+++ b/antislop-human.md
@@ -46,8 +46,9 @@ The home of the contrast checker. Three layers, from most to least convenient:
 
 ```bash
 python scripts/contrast-check.py "#FFFFFF" "#777777"
-# normal text: FAIL (4.48 < 4.5)
-# large text:  PASS (4.48 >= 3.0)
+# ratio: 4.48:1
+# normal text (4.5:1): FAIL
+# large text  (3.0:1): PASS
 ```
 
 The script exists so agents stop hallucinating AA. It takes two hex colors and prints the ratio and the verdict for both text sizes. It ships with the skill; if it is missing from an older setup, the formula and table below are complete on their own. Never block on the script.
@@ -63,14 +64,16 @@ The script exists so agents stop hallucinating AA. It takes two hex colors and p
 
 | Pairing (text on background) | Ratio | Normal text (4.5) | Large text (3.0) |
 |------------------------------|-------|-------------------|------------------|
-| Black on white | 21.0 | Pass | Pass |
-| White on black | 21.0 | Pass | Pass |
-| White on #333333 | 12.6 | Pass | Pass |
-| White on #666666 | 5.7 | Pass | Pass |
-| #777777 on white | 4.5 | Borderline, compute | Pass |
-| White on #888888 | 3.5 | Fail | Pass |
-| White on #999999 | 2.8 | Fail | Fail |
-| #555555 on black | 2.8 | Fail | Fail |
+| Black on white | 21.00 | Pass | Pass |
+| White on black | 21.00 | Pass | Pass |
+| White on #333333 | 12.63 | Pass | Pass |
+| White on #666666 | 5.74 | Pass | Pass |
+| #777777 on white | 4.48 | Fail | Pass |
+| White on #888888 | 3.54 | Fail | Pass |
+| White on #999999 | 2.85 | Fail | Fail |
+| #555555 on black | 2.82 | Fail | Fail |
+
+Ratios are given to two decimals because rounding hides failures: #777777 on white is 4.48, which fails the 4.5 bar, but reads as a pass once it is rounded to 4.5. `python scripts/contrast-check.py --selftest` asserts every row above, so the table and the script cannot drift apart.
 
 Read the table as a sanity check, not as a substitute. Any pairing not listed, or anything near a threshold, goes through the formula or the script.
 

--- a/antislop.md
+++ b/antislop.md
@@ -131,7 +131,7 @@ Anything presented as fact (testimonials, statistics, security claims) is real a
 
 ## Part 1: AI Slop Patterns (Warning Signs)
 
-These are the most common patterns found in AI-generated designs. Use this table to **audit** your output: scan for clusters, then ask each one "what does this serve?" A single pattern from this list is fine if it serves a purpose, unless a **Hard Gate** rule in Part 2 forbids it (R-02, R-17, R-18, R-23 to R-28, R-32 to R-38). What makes a design slop is many of these appearing together with no reason. This is a **diagnostic scan, not a ban list**: Part 1 itself bans nothing, but the Hard Gate rules in Part 2 are absolute, and every other pattern must pass the purpose test (Part 2, Purpose-Gate group).
+These are the most common patterns found in AI-generated designs. Use this table to **audit** your output: scan for clusters, then ask each one "what does this serve?" A single pattern from this list is fine if it serves a purpose, unless a **Hard Gate** rule in Part 2 forbids it (R-02, R-03, R-17, R-18, R-23 to R-28, R-32 to R-38). What makes a design slop is many of these appearing together with no reason. This is a **diagnostic scan, not a ban list**: Part 1 itself bans nothing, but the Hard Gate rules in Part 2 are absolute, and every other pattern must pass the purpose test (Part 2, Purpose-Gate group).
 
 ### Visual & Color
 
@@ -600,7 +600,7 @@ Before declaring the design done, answer every question below. All answers must 
 - [ ] Can the UI not be navigated by keyboard (Tab, Enter, Escape) or is there no visible focus state? *(R-32)*
 - [ ] Was any feature added by patching source/CSS with an external script instead of writing it in source? *(R-33)*
 - [ ] If a theme toggle exists, does one mode (light or dark) break styles, fonts, or layout? *(R-34)*
-- [ ] Was the app run/built and every interactive element exercised before delivery? *(R-35)*
+- [ ] Was the design delivered without running or building the app, or with any interactive element left unexercised? *(R-35)*
 - [ ] Are there any fabricated security, compliance, performance, or customer claims? *(R-36)*
 - [ ] Was the design built without a style direction, or was it built without direction AND not labeled *"draft without direction"* with honest default dials ENERGY 1 / RHYTHM 1 / MOTION 1? *(R-37)*
 - [ ] Is there any realistically-styled content that was fabricated (testimonials, features, statistics, ghost links, fictional team) without a real source? *(R-38)*

--- a/scripts/contrast-check.py
+++ b/scripts/contrast-check.py
@@ -4,6 +4,7 @@
 Usage:
     python contrast-check.py "#FFFFFF" "#777777"
     python contrast-check.py FFFFFF 777777
+    python contrast-check.py --selftest
 
 Prints the contrast ratio and a PASS/FAIL verdict for normal text (4.5:1)
 and large text (3:1, 18px+ per antislop R-25). Exit code 0 only when both
@@ -41,9 +42,41 @@ def contrast_ratio(color_a, color_b):
     return (lighter + 0.05) / (darker + 0.05)
 
 
+# The reference table in antislop-human.md. Kept here so the doc has an oracle:
+# a rounded ratio hides a failure (#777777 on white is 4.48, not 4.5).
+REFERENCE_PAIRS = [
+    ("#000000", "#FFFFFF", 21.00),
+    ("#FFFFFF", "#000000", 21.00),
+    ("#FFFFFF", "#333333", 12.63),
+    ("#FFFFFF", "#666666", 5.74),
+    ("#777777", "#FFFFFF", 4.48),
+    ("#FFFFFF", "#888888", 3.54),
+    ("#FFFFFF", "#999999", 2.85),
+    ("#555555", "#000000", 2.82),
+]
+
+
+def selftest():
+    for text, background, expected in REFERENCE_PAIRS:
+        got = round(contrast_ratio(text, background), 2)
+        assert got == expected, f"{text} on {background}: expected {expected}, got {got}"
+    assert parse_hex("#fff") == (255, 255, 255), "3-digit hex must expand"
+    assert parse_hex("777777") == (119, 119, 119), "a bare hex must parse"
+    for bad in ("#GGGGGG", "#FFFF", ""):
+        try:
+            parse_hex(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"{bad!r} should have been rejected")
+    print(f"selftest: {len(REFERENCE_PAIRS)} reference pairs OK")
+    return 0
+
+
 def main(argv):
+    if argv == ["--selftest"]:
+        return selftest()
     if len(argv) != 2:
-        print("usage: python contrast-check.py <hex1> <hex2>")
+        print("usage: python contrast-check.py <hex1> <hex2> | --selftest")
         return 2
     try:
         ratio = contrast_ratio(*argv)

--- a/scripts/contrast-check.py
+++ b/scripts/contrast-check.py
@@ -11,6 +11,7 @@ and large text (3:1, 18px+ per antislop R-25). Exit code 0 only when both
 verdicts pass, so scripts can chain on it.
 """
 
+import pathlib
 import re
 import sys
 
@@ -42,33 +43,67 @@ def contrast_ratio(color_a, color_b):
     return (lighter + 0.05) / (darker + 0.05)
 
 
-# The reference table in antislop-human.md. Kept here so the doc has an oracle:
-# a rounded ratio hides a failure (#777777 on white is 4.48, not 4.5).
-REFERENCE_PAIRS = [
-    ("#000000", "#FFFFFF", 21.00),
-    ("#FFFFFF", "#000000", 21.00),
-    ("#FFFFFF", "#333333", 12.63),
-    ("#FFFFFF", "#666666", 5.74),
-    ("#777777", "#FFFFFF", 4.48),
-    ("#FFFFFF", "#888888", 3.54),
-    ("#FFFFFF", "#999999", 2.85),
-    ("#555555", "#000000", 2.82),
-]
+# Row of the reference table in antislop-human.md, e.g.
+# | #777777 on white | 4.48 | Fail | Pass |
+TABLE_ROW = re.compile(
+    r"\|\s*(\S+)\s+on\s+(\S+)\s*\|\s*([\d.]+)\s*\|\s*(\w+)\s*\|\s*(\w+)\s*\|"
+)
+SKILL_DOC = "antislop-human.md"
+
+
+def _hex_of(name):
+    return {"black": "#000000", "white": "#FFFFFF"}.get(name.lower(), name)
+
+
+def check_reference_table(text):
+    """Recompute every row of the skill's table. Returns a list of mismatches."""
+    problems = []
+    rows = 0
+    for text_color, background, stated, normal, large in TABLE_ROW.findall(text):
+        rows += 1
+        pair = f"{text_color} on {background}"
+        got = round(contrast_ratio(_hex_of(text_color), _hex_of(background)), 2)
+        if got != float(stated):
+            problems.append(f"{pair}: table says {stated}, the formula says {got}")
+        for label, bar, stated_verdict in (("normal", 4.5, normal), ("large", 3.0, large)):
+            want = "pass" if got >= bar else "fail"
+            if stated_verdict.lower() != want:
+                problems.append(
+                    f"{pair}: {label} text marked {stated_verdict}, should be {want}"
+                )
+    if not rows:
+        problems.append(f"{SKILL_DOC}: no reference table rows found")
+    return rows, problems
 
 
 def selftest():
-    for text, background, expected in REFERENCE_PAIRS:
-        got = round(contrast_ratio(text, background), 2)
-        assert got == expected, f"{text} on {background}: expected {expected}, got {got}"
-    assert parse_hex("#fff") == (255, 255, 255), "3-digit hex must expand"
-    assert parse_hex("777777") == (119, 119, 119), "a bare hex must parse"
+    # No asserts anywhere in here: python -O strips them, and a checker that
+    # goes silently green under a common flag is worse than no checker.
+    problems = []
+    doc = pathlib.Path(__file__).resolve().parent.parent / SKILL_DOC
+    if doc.exists():
+        rows, problems = check_reference_table(doc.read_text(encoding="utf-8"))
+        checked = f"{rows} rows of the {SKILL_DOC} table"
+    else:
+        # The script is downloadable on its own, so a missing doc is not a failure.
+        checked = f"hex parsing only, no {SKILL_DOC} next to the script"
+
+    if parse_hex("#fff") != (255, 255, 255):
+        problems.append("a 3-digit hex must expand")
+    if parse_hex("777777") != (119, 119, 119):
+        problems.append("a bare hex must parse")
     for bad in ("#GGGGGG", "#FFFF", ""):
         try:
             parse_hex(bad)
         except ValueError:
             continue
-        raise AssertionError(f"{bad!r} should have been rejected")
-    print(f"selftest: {len(REFERENCE_PAIRS)} reference pairs OK")
+        problems.append(f"{bad!r} should have been rejected")
+
+    for problem in problems:
+        print(f"selftest: {problem}")
+    if problems:
+        return 1
+    print(f"selftest: {checked}, all OK")
     return 0
 
 


### PR DESCRIPTION
Closes #1, closes #2. Three factual errors, plus a selftest so two of them cannot come back.

Repro of the before state, straight from the tag:

```bash
mkdir before && cd before
B=https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v2.4.0
curl -sO $B/antislop.md -O $B/antislop-human.md
mkdir -p scripts && curl -so scripts/contrast-check.py $B/scripts/contrast-check.py
```

## The table and the script disagree about the same pair

Before, both files as shipped in v2.4.0:

```
$ grep '777777 on white' antislop-human.md
| #777777 on white | 4.5 | Borderline, compute | Pass |

$ python3 scripts/contrast-check.py "#777777" "#FFFFFF"
ratio: 4.48:1
normal text (4.5:1): FAIL
large text  (3.0:1): PASS
```

4.48 rounds to 4.5, and 4.5 reads as meeting the 4.5 bar. This is the one row where rounding flips the verdict, in the file written to stop agents asserting AA without computing.

After:

```
$ grep '777777 on white' antislop-human.md
| #777777 on white | 4.48 | Fail | Pass |

$ python3 scripts/contrast-check.py --selftest
selftest: 8 reference pairs OK

$ python3 scripts/contrast-check.py "#777777" "#FFFFFF"; echo "exit=$?"
ratio: 4.48:1
normal text (4.5:1): FAIL
large text  (3.0:1): PASS
exit=1
```

Every ratio now carries two decimals, matching what the script prints. `--selftest` parses the table out of `antislop-human.md` and recomputes each row, so the doc is the source and not a list hand-copied into the script. It checks the verdict columns too.

Negative control, putting the buggy row back into the table:

```
$ python3 scripts/contrast-check.py --selftest; echo "exit=$?"
selftest: #777777 on white: table says 4.5, the formula says 4.48
selftest: #777777 on white: normal text marked Borderline, should be fail
exit=1
```

Same result under `python -O`, which strips `assert`, so the check cannot go silently green:

```
$ python3 -O scripts/contrast-check.py --selftest; echo "exit=$?"
exit=1
```

With no `antislop-human.md` beside it, the script still runs its parsing checks and says so, because it is downloadable on its own. The two-argument CLI and its exit codes are untouched.

## The gate item is backwards in both directions

Block 1 requires every answer to be "no". Filling the R-35 item honestly:

| What actually happened | Before, honest answer | Before verdict | After, honest answer | After verdict |
|---|---|---|---|---|
| App never built or run | no | passes | yes | FAIL |
| App built, every control exercised | yes | FAIL | no | passes |

Before, the negligent delivery passes and the diligent one fails. Both rows are wrong, which is why this is a reword and not a wording preference. It was the only one of the 17 items in the block phrased as a positive.

## R-03 is a Hard Gate rule that Part 1 does not list

`#### R-03 — Mobile Responsiveness` is at line 232, under "Group 1: Hard Gate (absolute, no exceptions)". The Part 1 pointer:

```diff
- forbids it (R-02, R-17, R-18, R-23 to R-28, R-32 to R-38)
+ forbids it (R-02, R-03, R-17, R-18, R-23 to R-28, R-32 to R-38)
```

No rule text and no numbering changed.
