### PR TITLE
docs: sync v2.4.0 references and drop the dangling layoutmobile load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Dokumen audit/review internal — tidak untuk dipublish ke repo
+# Internal audit and review notes, not published to the repo
 docs/
 
 # OS noise

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -o antislop.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/m
 
 > "Read `antislop.md` and follow its install instructions. I want the UI skill."
 
-That's it. The pointer block is the source of truth: every later session loads the core plus only the skills you installed. Say "core only" to skip skills entirely. For a permanent setup that needs no first-run chat, add one line to your entry file (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, etc.): "For UI or copy work, read `antislop.md`."
+That's it. The pointer block is the source of truth: every later session loads the core plus only the skills you installed. Say "core only" to skip skills entirely. For a permanent setup that needs no first-run chat, add one line to your entry file (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, etc.): "For UI, copy, or people work, read `antislop.md`."
 
 **Manual (the 3-file system).**
 
@@ -50,10 +50,12 @@ curl -o antislop.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/m
 Then add a pointer block to your entry file, listing exactly the skills you installed:
 
 ```md
+<!-- antislop: auto-managed block, do not edit -->
 ## antislop
-For UI or copy work, read `antislop.md` (core) and then the skill for the task:
+For UI, copy, or people work, read `antislop.md` (core) and then the skill for the task:
 - UI / visual: `antislop-ui.md`
 - Copy & text: `antislop-copywriting.md`
+- People: `antislop-human.md`
 Before starting, ask the user when antislop applies: during the work, or after it is done.
 ```
 
@@ -65,12 +67,12 @@ You can optionally put a dial line in `DESIGN.md` (`Dial: ENERGY 2 / RHYTHM 3 / 
 |-------|----------------|----------|
 | `antislop-ui` | UI / visual: layout, color, components, decoration, motion, structure | v2.2.0 |
 | `antislop-copywriting` | Copy & text: headlines, CTAs, tone, fake stats, anti-AI-writing patterns, markdown hygiene | v2.3.0 |
-| `antislop-human` | Human: contrast, keyboard, focus, states | v2.4.0 (planned) |
+| `antislop-human` | Human: contrast, keyboard, focus, states | v2.4.0 |
 | `antislop-layoutmobile` | Mobile layout: responsive breakpoints, grids, overflow, tap targets | v2.5.0 (planned) |
 | `antislop-docs` | Documentation: READMEs, API references, changelogs, tutorials | v2.6.0 (planned) |
 | `antislop-identity` | Identity & naming: product names, taglines, brand voice | v2.7.0 (planned) |
 
-Pick what matches the work: UI work → `antislop-ui`, copy work → `antislop-copywriting`, both → "All", or none (the core alone is a complete filter).
+Pick what matches the work: UI work → `antislop-ui`, copy work → `antislop-copywriting`, accessibility work → `antislop-human`, any combination → "All", or none (the core alone is a complete filter).
 
 ## Usage Modes
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ curl -o antislop.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/m
 
 `antislop.md` alone is a complete filter. Skills add depth for one concern at a time; the wizard installs them, or download any you want the same way (`curl -o <skill-name>.md`).
 
+`antislop-human` also ships a contrast script. It is optional, the skill falls back to the formula without it, but the manual path has to fetch it explicitly:
+
+```bash
+mkdir -p scripts
+curl -o scripts/contrast-check.py https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/main/scripts/contrast-check.py
+```
+
 Then add a pointer block to your entry file, listing exactly the skills you installed:
 
 ```md

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can optionally put a dial line in `DESIGN.md` (`Dial: ENERGY 2 / RHYTHM 3 / 
 | `antislop-docs` | Documentation: READMEs, API references, changelogs, tutorials | v2.6.0 (planned) |
 | `antislop-identity` | Identity & naming: product names, taglines, brand voice | v2.7.0 (planned) |
 
-Pick what matches the work: UI work → `antislop-ui`, copy work → `antislop-copywriting`, accessibility work → `antislop-human`, any combination → "All", or none (the core alone is a complete filter).
+Pick what matches the work: UI work → `antislop-ui`, copy work → `antislop-copywriting`, people work → `antislop-human`, any combination → "All", or none (the core alone is a complete filter).
 
 ## Usage Modes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 ## Where we are
 
-The latest release is **v2.3.0**. antislop is now a **system**: a lean, always-loaded **core** (`antislop.md`, the complete rules filter, unchanged and backward compatible) plus two **skills**: `antislop-ui` (UI / visual) and `antislop-copywriting` (copy & text).
+The latest release is **v2.4.0**. antislop is now a **system**: a lean, always-loaded **core** (`antislop.md`, the complete rules filter, unchanged and backward compatible) plus three **skills**: `antislop-ui` (UI / visual), `antislop-copywriting` (copy & text), and `antislop-human` (contrast, keyboard, focus, states).
 
 The **First-Run Install Wizard** is still the install path: download `antislop.md` once, tell your agent to read it, and the agent walks you through choosing skills, downloads them into the same folder, and sets up the pointer for you. It is an offer, not a requirement: `antislop.md` alone remains a complete filter.
 
@@ -44,7 +44,7 @@ Target release: end of Q3 2026.
 - [x] v2.1.1 - English only; Indonesian mirrors removed
 - [x] v2.2.0 - core + First-Run Install Wizard + `antislop-ui` skill
 - [x] v2.3.0 - `antislop-copywriting` skill
-- [ ] v2.4.0 - `antislop-human`
+- [x] v2.4.0 - `antislop-human` (with the contrast checker script)
 - [ ] v2.5.0 - `antislop-layoutmobile`
 - [ ] v2.6.0 - `antislop-docs`
 - [ ] v2.7.0 - `antislop-identity`

--- a/antislop-human.md
+++ b/antislop-human.md
@@ -2,7 +2,7 @@
 
 > Anti AI Slop: Design & Copy Rules. Human skill
 
-> Part of the antislop system. Read together with `antislop.md` (the core). This skill deep-dives the human concern: the UI must stay usable by people with different eyes, hands, and setups. Contrast, keyboard, focus, states, and the mobile details that exclude people. The layout mechanics behind mobile (breakpoints, grids, overflow, tap targets) live in `antislop-layoutmobile`.
+> Part of the antislop system. Read together with `antislop.md` (the core). This skill deep-dives the human concern: the UI must stay usable by people with different eyes, hands, and setups. Contrast, keyboard, focus, states, and the mobile details that exclude people.
 
 ## How to use this skill
 
@@ -10,7 +10,7 @@
 - Every entry has the same shape: **Tell** (the pattern), **Why** (who it excludes, and why it reads as unfinished), **Fix** (what to do instead), with the governing core rule cited as R-XX.
 - Accessibility is not a checklist of extras bolted on at the end. It is part of the core promise that "the UI holds up" (C-4). The Delivery Gate in the core remains the gate; the "Human Skill Checklist" at the end of this file is the supplement to run alongside it.
 - The contrast checker (formula + reference table + script) lives in this skill. Use it for every color pairing you cannot verify by eye.
-- For the layout mechanics behind mobile (breakpoints, grids, overflow, tap targets), load `antislop-layoutmobile` together with this skill. This skill keeps only the mobile details that exclude people: zooming, and the on-screen keyboard.
+- This skill keeps only the mobile details that exclude people: zooming, and the on-screen keyboard. The layout mechanics behind mobile (breakpoints, grids, overflow, tap targets) belong to `antislop-layoutmobile`, which ships in v2.5.0. Until then they are covered by R-03 in the core; do not try to load a skill file that does not exist yet.
 
 ## Color & Contrast
 
@@ -116,7 +116,7 @@ Read the table as a sanity check, not as a substitute. Any pairing not listed, o
 
 ## Zoom & Mobile Use
 
-The layout mechanics behind mobile (breakpoints, grids, overflow, tap targets) live in `antislop-layoutmobile`. This section keeps only the mobile details that exclude people: zooming, and the on-screen keyboard.
+This section keeps only the mobile details that exclude people: zooming, and the on-screen keyboard.
 
 ### Text That Cannot Zoom
 


### PR DESCRIPTION
Closes #3. Docs only. No rule text, no numbering, no behaviour change.

## The load instruction points at a 404

`antislop-human.md` line 13 tells the agent to load `antislop-layoutmobile` together with this skill. That file exists in no release:

```
$ for t in v2.4.0 v2.3.0 main; do
    curl -s -o /dev/null -w "$t %{http_code}\n" \
      https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/$t/antislop-layoutmobile.md
  done
v2.4.0 404
v2.3.0 404
main 404
```

After: one sentence that names v2.5.0 and cites R-03 for the interim, and no instruction to load anything. The same sentence appeared three times in the file, so this also drops two verbatim repeats.

## The pointer block drops the skill the wizard just installed

The wizard downloads three skills:

```
$ grep -c 'curl -o antislop-' antislop.md
3
```

The block a manual installer is told to write names two:

```
$ sed -n '/Then add a pointer block/,/^```$/p' README.md | grep -E '^- |^For '
For UI or copy work, read `antislop.md` (core) and then the skill for the task:
- UI / visual: `antislop-ui.md`
- Copy & text: `antislop-copywriting.md`
```

`antislop.md` documents that block as the source of truth for which skills are installed, so `antislop-human.md` lands on disk and is never read. After, the block matches what the wizard writes, marker line included:

```md
<!-- antislop: auto-managed block, do not edit -->
## antislop
For UI, copy, or people work, read `antislop.md` (core) and then the skill for the task:
- UI / visual: `antislop-ui.md`
- Copy & text: `antislop-copywriting.md`
- People: `antislop-human.md`
Before starting, ask the user when antislop applies: during the work, or after it is done.
```

## Version drift

| Where | Said | Actual |
|---|---|---|
| README skills table | `antislop-human` ... v2.4.0 (planned) | shipped |
| ROADMAP "Where we are" | latest is v2.3.0, two skills | v2.4.0, three skills |
| ROADMAP status | `- [ ] v2.4.0` | done |

Also translates the one Indonesian comment left in `.gitignore`, which the v2.1.1 English-only pass missed.

Merges cleanly with #4, verified locally; the two touch different parts of `antislop-human.md`.

The manual install section also now fetches `scripts/contrast-check.py`. Adding `antislop-human` to the pointer block is what makes that path reachable, and the manual instructions only covered `curl -o <skill-name>.md`, so the script the skill runs never arrived. Marked optional, since the skill falls back to the formula without it.
