### PR TITLE
docs: tick v2.4.1 and drop the em dash README adds outside the carve-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl -o antislop.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/m
 
 `antislop.md` alone is a complete filter. Skills add depth for one concern at a time; the wizard installs them, or download any you want the same way (`curl -o <skill-name>.md`).
 
-`antislop-human` also runs `scripts/contrast-check.py` to verify color pairs you cannot judge by eye. Fetch it the same way, if you want it (optional — the skill falls back to the formula and reference table without it):
+`antislop-human` also runs `scripts/contrast-check.py` to verify color pairs you cannot judge by eye. Fetch it the same way, if you want it (optional: the skill falls back to the formula and reference table without it):
 
 ```bash
 curl -o scripts/contrast-check.py https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/main/scripts/contrast-check.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ Target release: end of Q3 2026.
 - [x] v2.2.0 - core + First-Run Install Wizard + `antislop-ui` skill
 - [x] v2.3.0 - `antislop-copywriting` skill
 - [x] v2.4.0 - `antislop-human`
-- [ ] v2.4.1 - `guide.md`: plain-English guide for people new to antislop (not a skill); fixes for issues #1, #2, #3, #6, #7
+- [x] v2.4.1 - `guide.md`: plain-English guide for people new to antislop (not a skill); fixes for issues #1, #2, #3, #6, #7
 - [ ] v2.5.0 - `antislop-layoutmobile`
 - [ ] v2.6.0 - `antislop-docs`
 - [ ] v2.7.0 - `antislop-identity`


### PR DESCRIPTION
Two one-line documentation fixes. No rule text, no numbering, no behaviour change.

`ROADMAP.md:48` still shows `- [ ] v2.4.1` while line 7 of the same file says v2.4.1 is the latest release and the tag is published.

`README.md:52` carries an em dash. The carve-out added under R-02 in v2.4.1 exempts the headings in `antislop.md`, the rule's own definition, the Part 1 example, the Delivery Gate item that quotes the character, and the `Em Dashes` section of `antislop-copywriting.md`. README is not on that list, and this is the only em dash left in the repo outside the carve-out. A colon carries the same aside. The line arrived in #5, which was mine.

Before, on `v2.4.1`:

```
$ grep -rn '[—–]' README.md ROADMAP.md
README.md:52:... Fetch it the same way, if you want it (optional — the skill falls back to the formula and reference table without it):
$ grep -n '] v2.4.1' ROADMAP.md
48:- [ ] v2.4.1 - `guide.md`: plain-English guide for people new to antislop (not a skill); fixes for issues #1, #2, #3, #6, #7
```

After:

```
$ grep -rn '[—–]' README.md ROADMAP.md; echo "exit=$?"
exit=1
$ grep -n '] v2.4.1' ROADMAP.md
48:- [x] v2.4.1 - `guide.md`: plain-English guide for people new to antislop (not a skill); fixes for issues #1, #2, #3, #6, #7
```
