### PR TITLE
fix: give each skill checklist the polarity its items actually use

### DIFF
--- a/antislop-copywriting.md
+++ b/antislop-copywriting.md
@@ -309,7 +309,7 @@ Run this loop before delivering copy:
 
 ## Copywriting Skill Checklist
 
-Run these alongside the core Delivery Gate when the task is copy work. Any **yes** on a must-be-no item, or **no** on a must-be-yes item, is a FAIL:
+Run these alongside the core Delivery Gate when the task is copy work. Every line below must be true:
 
 - [ ] No fabricated numbers, testimonials, names, dates, or claims; everything real or a labeled placeholder (R-17, R-18, R-36, R-38)
 - [ ] Buzzwords from R-16 and the Empty AI Vocabulary list replaced with specific, evidenced language

--- a/antislop-human.md
+++ b/antislop-human.md
@@ -132,7 +132,7 @@ The layout mechanics behind mobile (breakpoints, grids, overflow, tap targets) a
 
 ## Human Skill Checklist
 
-Run these alongside the core Delivery Gate when the task involves UI. Any **yes** on a must-be-no item, or **no** on a must-be-yes item, is a FAIL:
+Run these alongside the core Delivery Gate when the task involves UI. All answers must be **yes**:
 
 - [ ] Is every text and background pairing verified against the contrast checker (formula, table, or script), including text over images and gradients? (R-25)
 - [ ] Does every interactive component boundary and status indicator meet 3:1 against its background? (non-text contrast)

--- a/antislop-ui.md
+++ b/antislop-ui.md
@@ -190,7 +190,7 @@
 
 ## UI Skill Checklist
 
-Run these alongside the core Delivery Gate when the task is UI work. Any **yes** on a must-be-no item, or **no** on a must-be-yes item, is a FAIL:
+Run these alongside the core Delivery Gate when the task is UI work. All answers must be **yes**:
 
 - [ ] Is the palette derived from `DESIGN.md` or a written brand identity, not the default gradient set? (R-01, R-29)
 - [ ] Is the accent used at the key moment only, not spread across every element? (core Part 3, one deliberate accent)


### PR DESCRIPTION
Closes #9. Three lines, one per skill file. No item text, no rule text, no numbering.

The wording follows the core, which states the polarity per block and keeps each block uniform (`antislop.md:589` "All answers must be **no**", `:628` "All answers must be **yes**"). So `antislop-ui` and `antislop-human` get `All answers must be **yes**:`, since every item under those headers passes on yes.

`antislop-copywriting` gets `Every line below must be true:` instead. Its items are assertions rather than questions ("No fabricated numbers...", "Voice present: ..."), so yes and no never mapped onto them.

```diff
-Run these alongside the core Delivery Gate when the task is UI work. Any **yes** on a must-be-no item, or **no** on a must-be-yes item, is a FAIL:
+Run these alongside the core Delivery Gate when the task is UI work. All answers must be **yes**:
```

The wording is yours to pick. If you would rather phrase it another way, or turn the copywriting items into questions and use the same sentence in all three files, say so and I will redo it. It stays one line per file either way.
