### PR TITLE
fix: call python3, not python, so the contrast tooling runs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
   "skills": ["./skills/"],
   "mcpServers": {
     "antislop-contrast": {
-      "command": "python",
+      "command": "python3",
       "args": ["${CLAUDE_PLUGIN_ROOT}/skills/antislop-human/contrast-mcp.py"],
       "env": {}
     }

--- a/skills/antislop-human/SKILL.md
+++ b/skills/antislop-human/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-human
 description: "Human and accessibility skill for antislop. Contrast, keyboard, focus, and states for real people. Includes the contrast checker."
-allowed-tools: Bash(python *) Read Write Edit Glob Grep
+allowed-tools: Bash(python3 *) Read Write Edit Glob Grep
 ---
 # antislop-human
 
@@ -50,7 +50,7 @@ The home of the contrast checker. Three layers, from most to least convenient:
 **The script.** When a script runtime is available and the file is present, run it instead of computing by hand. The script ships in this skill's folder (`contrast-check.py`, next to this `SKILL.md`):
 
 ```bash
-python "${CLAUDE_SKILL_DIR}/contrast-check.py" "#FFFFFF" "#777777"
+python3 "${CLAUDE_SKILL_DIR}/contrast-check.py" "#FFFFFF" "#777777"
 # normal text: FAIL (4.48 < 4.5)
 # large text:  PASS (4.48 >= 3.0)
 ```

--- a/skills/antislop-human/contrast-check.py
+++ b/skills/antislop-human/contrast-check.py
@@ -2,9 +2,9 @@
 """WCAG 2.x contrast checker, home of the antislop-human contrast checker.
 
 Usage:
-    python contrast-check.py "#FFFFFF" "#777777"
-    python contrast-check.py FFFFFF 777777
-    python contrast-check.py --selftest
+    python3 contrast-check.py "#FFFFFF" "#777777"
+    python3 contrast-check.py FFFFFF 777777
+    python3 contrast-check.py --selftest
 
 Prints the contrast ratio and a PASS/FAIL verdict for normal text (4.5:1)
 and large text (3:1, 18px+ per antislop R-25). Exit code 0 only when both
@@ -142,7 +142,7 @@ def main(argv):
     if len(argv) == 1 and argv[0] == "--selftest":
         return selftest()
     if len(argv) != 2:
-        print("usage: python contrast-check.py <hex1> <hex2> | --selftest")
+        print("usage: python3 contrast-check.py <hex1> <hex2> | --selftest")
         return 2
     try:
         ratio = contrast_ratio(parse_hex(argv[0]), parse_hex(argv[1]))


### PR DESCRIPTION
**What this fixes:** the contrast checker that ships with `antislop-human` cannot run on a default macOS or Debian machine, because v3.0.0 calls it with `python`.

![Before: python is not on a stock PATH so the MCP server never starts. After: the same file answers an initialize handshake under python3](https://raw.githubusercontent.com/fajarhide/anti-slop/demo-assets/demo/pr11-before-after.png)

Those systems install `python3` only. Nothing named `python` is on PATH, so the `antislop-contrast` MCP server declared in plugin.json never starts, and the command the skill prints for the agent fails the same way.

```
$ env -i PATH=/usr/bin:/bin sh -c 'python skills/antislop-human/contrast-mcp.py'
sh: python: command not found

$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | python3 skills/antislop-human/contrast-mcp.py
{"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "antislop-contrast", "version": "3.0.0"}}}
```

**What changed:** four sites now say `python3`. The `command` in plugin.json, the `allowed-tools` rule and the example block in `antislop-human/SKILL.md`, and the usage strings in `contrast-check.py`. Both scripts already carry `#!/usr/bin/env python3`, so this is what they were written for.

The `allowed-tools` one matters on its own. `Bash(python *)` does not pre-approve `python3 ...`, so the agent hits a permission prompt even on a machine where the script works.

After the change:

```
$ python3 skills/antislop-human/contrast-check.py --selftest
selftest: 8 reference pairs OK

$ claude plugin validate .
✔ Validation passed
$ claude plugin validate ./skills
✔ Validation passed
```
