### PR TITLE
fix(cli): write the pointer to the file each agent reads, and stop importing the core

### DIFF
--- a/antislop.md
+++ b/antislop.md
@@ -43,7 +43,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
    ```
 5. **Append the pointer block at the END of the project's entry file** (the file the running tool reads at session start: `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex, `GEMINI.md` for Gemini CLI, and so on). If that file does not exist, create it. Never modify existing content:
    ```md
-   <!-- antislop: auto-managed block, do not edit -->
+   <!-- antislop:start -->
    ## antislop
    For UI, copy, people, or mobile layout work, read `antislop.md` (core) and then the skill for the task:
    - UI / visual: `skills/antislop-ui/SKILL.md`
@@ -51,8 +51,9 @@ If no antislop pointer exists and this file is being read for the first time, ru
    - People: `skills/antislop-human/SKILL.md`
    - Mobile / responsive: `skills/antislop-layoutmobile/SKILL.md`
    Before starting, ask the user when antislop applies: during the work, or after it is done.
+   <!-- antislop:end -->
    ```
-   If an older antislop block exists (even without the marker), replace just that block instead of appending a duplicate.
+   The packaged installers write the same two markers, so whichever install path runs last replaces the block instead of adding a second one. If an older antislop block exists (even without the markers), replace just that block instead of appending a duplicate.
 6. **Ask the usage-mode question** (see "Two Usage Modes"), then proceed with the work.
 
 Notes:

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import path from 'node:path'
 import pc from 'picocolors'
 import { intro, outro, select, multiselect, confirm, isCancel, cancel, log, spinner } from '@clack/prompts'
 import { banner } from './lib/banner.mjs'
@@ -86,10 +87,12 @@ async function main() {
   const spin = spinner()
   spin.start('Installing skills...')
   const written = installSkills({ skills, targets, overwrite })
-  if (location === 'project') {
-    updatePointers({ targets })
-  }
+  const pointers = location === 'project' ? updatePointers({ targets, skills }) : []
   spin.stop('Done.')
+
+  if (pointers.length > 0) {
+    log.step('Pointer written to ' + pointers.map((p) => path.basename(p)).join(', '))
+  }
 
   const agentCount = new Set(written.map((w) => w.agent.id)).size
   if (written.length > 0) {

--- a/cli/lib/install.mjs
+++ b/cli/lib/install.mjs
@@ -29,7 +29,6 @@ export function resolveTargets(location) {
   const base = resolveBase(location)
   return AGENTS.map((agent) => ({ agent, path: path.join(base, agent.dir) }))
     .filter((t) => {
-      if (location === 'global') return true
       if (t.agent.id === 'claude') return true
       const parent = path.join(base, t.agent.dir.split('/')[0])
       return fs.existsSync(parent)
@@ -79,34 +78,61 @@ export function installSkills({ skills, targets, overwrite = false }) {
 const POINTER_START = '<!-- antislop:start -->'
 const POINTER_END = '<!-- antislop:end -->'
 
-export function updatePointers({ targets }) {
-  const projectRoot = process.cwd()
-  const entry = path.join(projectRoot, 'AGENTS.md')
+// The entry file each agent reads at session start.
+const ENTRY_FILE = { claude: 'CLAUDE.md', codex: 'AGENTS.md', antigravity: 'AGENTS.md' }
 
-  const coreTarget = targets.find((t) => fs.existsSync(path.join(t.path, CORE)))
-  if (!coreTarget) return
+const SKILL_LINES = {
+  [CORE]: 'Core filter, always on: `antislop`',
+  'antislop-ui': 'UI / visual: `antislop-ui`',
+  'antislop-copywriting': 'Copy & text: `antislop-copywriting`',
+  'antislop-human': 'People: `antislop-human`',
+  'antislop-layoutmobile': 'Mobile / responsive: `antislop-layoutmobile`',
+}
 
-  const rel = path
-    .relative(projectRoot, path.join(coreTarget.path, CORE, 'SKILL.md'))
-    .split(path.sep)
-    .join('/')
+// Names the skills instead of importing the core. The skills sit in the agent's
+// own folder, so the agent already finds them; an `@` import would also pull all
+// 46 KB of the core into every session, including sessions that touch no UI.
+function pointerBlock(skills) {
+  return [
+    POINTER_START,
+    '## antislop',
+    'For UI, copy, people, or mobile layout work, load the antislop skill for the task:',
+    ...skills.filter((s) => SKILL_LINES[s]).map((s) => `- ${SKILL_LINES[s]}`),
+    'Before starting, ask the user when antislop applies: during the work, or after it is done.',
+    POINTER_END,
+  ]
+}
 
+function writeBlock(entry, block) {
   const existing = fs.existsSync(entry) ? fs.readFileSync(entry, 'utf8') : ''
   const lines = existing.split(/\r?\n/)
-  const startIdx = lines.findIndex((l) => l.trim() === POINTER_START)
-  const endIdx = lines.findIndex((l) => l.trim() === POINTER_END)
-  const head = startIdx !== -1 && endIdx !== -1 && startIdx < endIdx ? lines.slice(0, startIdx) : lines
-  const tail = startIdx !== -1 && endIdx !== -1 && startIdx < endIdx ? lines.slice(endIdx + 1) : []
+  const start = lines.findIndex((l) => l.trim() === POINTER_START)
+  const end = lines.findIndex((l) => l.trim() === POINTER_END)
+  const replacing = start !== -1 && end !== -1 && start < end
+  const head = replacing ? lines.slice(0, start) : lines
+  const tail = replacing ? lines.slice(end + 1) : []
 
-  const block = [POINTER_START, `@${rel}`, POINTER_END]
-  const body = [...head, ...block, ...tail]
-    .filter((l, i, arr) => {
-      if (l.trim() !== '') return true
-      const prev = arr[i - 1]
-      return !(prev === undefined || prev.trim() === '')
-    })
+  const body = [...head, '', ...block, '', ...tail]
     .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^\n+/, '')
     .trimEnd()
 
   fs.writeFileSync(entry, body + '\n')
+}
+
+export function updatePointers({ targets, skills }) {
+  const entries = new Set()
+  for (const t of targets) {
+    if (fs.existsSync(path.join(t.path, CORE))) entries.add(ENTRY_FILE[t.agent.id])
+  }
+
+  const block = pointerBlock(skills)
+  const written = []
+  for (const name of entries) {
+    const entry = path.join(process.cwd(), name)
+    writeBlock(entry, block)
+    written.push(entry)
+  }
+  return written
 }

--- a/cli/scripts/smoke-test.mjs
+++ b/cli/scripts/smoke-test.mjs
@@ -31,12 +31,11 @@ if (result.status !== 0) console.log('worker stderr:', result.stderr)
 console.log('\n--- files written to temp project ---')
 console.log(tree(tmp).join('\n'))
 
-const agentsPath = path.join(tmp, 'AGENTS.md')
-if (fs.existsSync(agentsPath)) {
-  console.log('\n--- AGENTS.md ---')
-  console.log(fs.readFileSync(agentsPath, 'utf8'))
-} else {
-  console.log('\nAGENTS.md was not created (pointer step skipped).')
+for (const name of ['CLAUDE.md', 'AGENTS.md']) {
+  const entry = path.join(tmp, name)
+  if (!fs.existsSync(entry)) continue
+  console.log(`\n--- ${name} ---`)
+  console.log(fs.readFileSync(entry, 'utf8'))
 }
 
 const coreSkill = path.join(tmp, '.claude', 'skills', 'antislop', 'SKILL.md')

--- a/cli/scripts/smoke-worker.mjs
+++ b/cli/scripts/smoke-worker.mjs
@@ -7,12 +7,13 @@ const skills = ['antislop', 'antislop-ui']
 const targets = resolveTargets('project')
 let conflicts = detectConflicts({ skills, targets })
 let written = installSkills({ skills, targets, overwrite: false })
-updatePointers({ targets })
+const pointers = updatePointers({ targets, skills })
 
 console.log('cwd:', process.cwd())
 console.log('A targets:', targets.map((t) => `${t.agent.id}@${t.path} exists=${t.exists}`).join(' | '))
 console.log('A conflicts:', conflicts.length, '(fresh project, expect 0)')
 console.log('A written:', written.map((w) => `${w.agent.id}:${w.skill}`).join(', '))
+console.log('A pointers:', pointers.map((p) => path.basename(p)).join(', '), '(expect CLAUDE.md)')
 
 conflicts = detectConflicts({ skills, targets })
 written = installSkills({ skills, targets, overwrite: false })
@@ -28,3 +29,7 @@ console.log('D global targets:', globalTargets.map((t) => `${t.agent.id}@${t.pat
 const src = fs.readFileSync(path.join(skillSourceDir(), 'antislop-ui', 'SKILL.md'), 'utf8')
 const dst = fs.readFileSync(path.join(process.cwd(), '.claude', 'skills', 'antislop-ui', 'SKILL.md'), 'utf8')
 console.log('E antislop-ui SKILL.md identical:', src === dst)
+
+updatePointers({ targets, skills })
+const entry = fs.readFileSync(path.join(process.cwd(), 'CLAUDE.md'), 'utf8')
+console.log('F blocks after a second run:', (entry.match(/antislop:start/g) || []).length, '(expect 1)')

--- a/skills/antislop/SKILL.md
+++ b/skills/antislop/SKILL.md
@@ -48,7 +48,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
    ```
 5. **Append the pointer block at the END of the project's entry file** (the file the running tool reads at session start: `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex, `GEMINI.md` for Gemini CLI, and so on). If that file does not exist, create it. Never modify existing content:
    ```md
-   <!-- antislop: auto-managed block, do not edit -->
+   <!-- antislop:start -->
    ## antislop
    For UI, copy, people, or mobile layout work, read `antislop.md` (core) and then the skill for the task:
    - UI / visual: `skills/antislop-ui/SKILL.md`
@@ -56,8 +56,9 @@ If no antislop pointer exists and this file is being read for the first time, ru
    - People: `skills/antislop-human/SKILL.md`
    - Mobile / responsive: `skills/antislop-layoutmobile/SKILL.md`
    Before starting, ask the user when antislop applies: during the work, or after it is done.
+   <!-- antislop:end -->
    ```
-   If an older antislop block exists (even without the marker), replace just that block instead of appending a duplicate.
+   The packaged installers write the same two markers, so whichever install path runs last replaces the block instead of adding a second one. If an older antislop block exists (even without the markers), replace just that block instead of appending a duplicate.
 6. **Ask the usage-mode question** (see "Two Usage Modes"), then proceed with the work.
 
 Notes:


### PR DESCRIPTION
Closes #13.

**What this fixes:** the pointer `npx antislop-ai` writes went to the wrong file, said the wrong thing, and could not be replaced by the wizard.

![Before: an at-import in AGENTS.md. After: a pointer block in CLAUDE.md naming the installed skills](https://raw.githubusercontent.com/fajarhide/anti-slop/demo-assets/demo/pr15-before-after.png)

Before, a project install wrote this to `AGENTS.md` no matter which agent was installed:

```
<!-- antislop:start -->
@.claude/skills/antislop/SKILL.md
<!-- antislop:end -->
```

After:

```
$ node cli/scripts/smoke-test.mjs

--- files written to temp project ---
.claude/
  skills/
    antislop/
      SKILL.md
    antislop-ui/
      SKILL.md
CLAUDE.md

--- CLAUDE.md ---
<!-- antislop:start -->
## antislop
For UI, copy, people, or mobile layout work, load the antislop skill for the task:
- Core filter, always on: `antislop`
- UI / visual: `antislop-ui`
Before starting, ask the user when antislop applies: during the work, or after it is done.
<!-- antislop:end -->
```

Three changes:

1. **The file each agent reads.** `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex and Antigravity, and only for agents that actually got skills.
2. **A pointer, not an import.** The skills sit in the agent's own folder, so the agent already finds them. Dropping the `@` import keeps 46 KB of core out of every session that touches no UI.
3. **One marker pair.** `antislop.md` step 5 now writes `<!-- antislop:start -->` and `<!-- antislop:end -->` too, so whichever install path runs last replaces the block instead of leaving two.

Also in the same file: a global install no longer creates `~/.agents/skills` and `~/.codex/skills` for tools the user does not have. It uses the parent-exists check the project path already had, with Claude Code always included so a fresh machine still gets a target.

```
$ HOME=/tmp/fakehome node -e "... resolveTargets('global') ..."
no codex/agents dirs: claude
after mkdir ~/.codex: claude, codex
```

Verified: the block replaces the old `@` import in place and leaves the rest of an existing `CLAUDE.md` untouched, and a second run leaves one block, not two (`F blocks after a second run: 1`). `skills/antislop/SKILL.md` regenerated with `npm run sync-skills`.

The pointer choice is the part worth arguing with. If you would rather keep the import, or drop the pointer entirely for agents that auto-discover skills, say so and I will redo it that way.
