### PR TITLE
fix(core): stop the first-run wizard downloading skills at runtime (Snyk W012)

### DIFF
--- a/antislop.md
+++ b/antislop.md
@@ -32,15 +32,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
    - **1. The user supplies direction (recommended).** They write their own `DESIGN.md`, or answer a few direction questions (identity, personality, palette, typography, mood) and the agent transcribes their answers into `DESIGN.md`. The user is the author; the agent only formats. Never invent example content for `DESIGN.md`.
    - **2. The agent supplies direction, with an honest warning.** The agent writes the direction itself, stating explicitly that agent-generated style tends toward default AI taste, which is the slop antislop filters, so the result is likely monotonous. If chosen, still ask a minimal brief (product, audience, mood) before building.
    - **3. The user skips direction for now.** Proceed without a `DESIGN.md`. Any UI built this way must be labeled *"draft without direction"* with dials ENERGY 1 / RHYTHM 1 / MOTION 1 (R-37), and is not a shippable deliverable.
-4. **Download the chosen skill(s)** into `skills/<name>/` subfolders next to this file, pinned to the release tag that matches this version so a newer skill never mixes with an older core. When `antislop-human` is chosen, also download its contrast-check script into the same skill folder:
-   ```bash
-   mkdir -p skills/antislop-ui skills/antislop-copywriting skills/antislop-human skills/antislop-layoutmobile
-   curl -o skills/antislop-ui/SKILL.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v3.0.2/skills/antislop-ui/SKILL.md
-   curl -o skills/antislop-copywriting/SKILL.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v3.0.2/skills/antislop-copywriting/SKILL.md
-   curl -o skills/antislop-human/SKILL.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v3.0.2/skills/antislop-human/SKILL.md
-   curl -o skills/antislop-layoutmobile/SKILL.md https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v3.0.2/skills/antislop-layoutmobile/SKILL.md
-   curl -o skills/antislop-human/contrast-check.py https://raw.githubusercontent.com/miqdadbadjuber/anti-slop/v3.0.2/skills/antislop-human/contrast-check.py
-   ```
+4. **Get the chosen skill(s) in place; the user does the fetching, never the agent.** A `SKILL.md` is instructions the agent will obey, so an agent that downloads one at runtime is fetching its own next prompt: do not do it, and do not ask for network access here. Tell the user to run `npx antislop-ai` (the picker, adds and removes skills), or `npx skills add miqdadbadjuber/anti-slop`, or, with no terminal, to open `skills/<name>/SKILL.md` in the repo and paste it into `skills/<name>/SKILL.md` next to this file. `antislop-human` also needs `contrast-check.py` from that same folder. Whatever the route, take the files from the release tag that matches this core so a newer skill never mixes with an older one.
 5. **Append the pointer block at the END of the project's entry file** (the file the running tool reads at session start: `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex, `GEMINI.md` for Gemini CLI, and so on). If that file does not exist, create it. Never modify existing content:
    ```md
    <!-- antislop:start -->
@@ -58,7 +50,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
 
 Notes:
 - The entry file is read at the start of a session, so a newly written pointer takes effect from the **next** session.
-- The wizard needs download and file-write access for steps 4 and 5; the user approves once.
+- The wizard needs file-write access for step 5 (the pointer block), and nothing else; the user approves once. It never needs network access.
 - The pointer block is the source of truth for which skills are installed. To add or remove a skill later, update the block to match (add or remove the file and its line).
 
 ---

--- a/cli/scripts/sync-skills.mjs
+++ b/cli/scripts/sync-skills.mjs
@@ -16,21 +16,14 @@ const CORE_FRONTMATTER = [
   '',
 ].join('\n')
 
-const NO_DOWNLOAD_STEP = '4. **No download needed.** The skill folders are already installed next to this core: the picker (`npx antislop-ai`) and the skills directory (`npx skills add miqdadbadjuber/anti-slop`) copy them into place. To add or remove a skill later, run `npx antislop-ai` again.'
-
-let coreBody = fs.readFileSync(path.join(repoRoot, 'antislop.md'), 'utf8')
+const coreBody = fs.readFileSync(path.join(repoRoot, 'antislop.md'), 'utf8')
   .replace(/\r\n/g, '\n')
   .trim()
 
-if (coreBody.includes('4. **Download the chosen skill(s)**')) {
-  coreBody = coreBody.replace(
-    /4\. \*\*Download the chosen skill\(s\)\*\*[\s\S]*?\n   ```\n(?=5\. )/,
-    NO_DOWNLOAD_STEP + '\n\n'
-  )
-  coreBody = coreBody.replace(
-    /- The wizard needs download and file-write access for steps 4 and 5; the user approves once\./,
-    '- The wizard needs file-write access for step 5 (the pointer block); the user approves once. Skills are already installed in this packaged form.'
-  )
+// A shipped skill must not tell the agent to download the rest of its own instructions:
+// that is Snyk W012, and it cost us one MEDIUM finding on the directory listing already.
+if (/https?:\/\/raw\.githubusercontent\.com/.test(coreBody)) {
+  throw new Error('antislop.md carries a runtime download URL; remove it before syncing (Snyk W012)')
 }
 
 fs.writeFileSync(path.join(repoSkills, 'antislop', 'SKILL.md'), CORE_FRONTMATTER + coreBody + '\n')

--- a/skills/antislop/SKILL.md
+++ b/skills/antislop/SKILL.md
@@ -37,8 +37,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
    - **1. The user supplies direction (recommended).** They write their own `DESIGN.md`, or answer a few direction questions (identity, personality, palette, typography, mood) and the agent transcribes their answers into `DESIGN.md`. The user is the author; the agent only formats. Never invent example content for `DESIGN.md`.
    - **2. The agent supplies direction, with an honest warning.** The agent writes the direction itself, stating explicitly that agent-generated style tends toward default AI taste, which is the slop antislop filters, so the result is likely monotonous. If chosen, still ask a minimal brief (product, audience, mood) before building.
    - **3. The user skips direction for now.** Proceed without a `DESIGN.md`. Any UI built this way must be labeled *"draft without direction"* with dials ENERGY 1 / RHYTHM 1 / MOTION 1 (R-37), and is not a shippable deliverable.
-4. **No download needed.** The skill folders are already installed next to this core: the picker (`npx antislop-ai`) and the skills directory (`npx skills add miqdadbadjuber/anti-slop`) copy them into place. To add or remove a skill later, run `npx antislop-ai` again.
-
+4. **Get the chosen skill(s) in place; the user does the fetching, never the agent.** A `SKILL.md` is instructions the agent will obey, so an agent that downloads one at runtime is fetching its own next prompt: do not do it, and do not ask for network access here. Tell the user to run `npx antislop-ai` (the picker, adds and removes skills), or `npx skills add miqdadbadjuber/anti-slop`, or, with no terminal, to open `skills/<name>/SKILL.md` in the repo and paste it into `skills/<name>/SKILL.md` next to this file. `antislop-human` also needs `contrast-check.py` from that same folder. Whatever the route, take the files from the release tag that matches this core so a newer skill never mixes with an older one.
 5. **Append the pointer block at the END of the project's entry file** (the file the running tool reads at session start: `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex, `GEMINI.md` for Gemini CLI, and so on). If that file does not exist, create it. Never modify existing content:
    ```md
    <!-- antislop:start -->
@@ -56,7 +55,7 @@ If no antislop pointer exists and this file is being read for the first time, ru
 
 Notes:
 - The entry file is read at the start of a session, so a newly written pointer takes effect from the **next** session.
-- The wizard needs file-write access for step 5 (the pointer block); the user approves once. Skills are already installed in this packaged form.
+- The wizard needs file-write access for step 5 (the pointer block), and nothing else; the user approves once. It never needs network access.
 - The pointer block is the source of truth for which skills are installed. To add or remove a skill later, update the block to match (add or remove the file and its line).
 
 ---


### PR DESCRIPTION
Step 4 of the first-run wizard in `antislop.md` tells the agent to download four `SKILL.md` files and `contrast-check.py` from raw.githubusercontent. A `SKILL.md` is instructions the agent then obeys, so that step has the agent fetching its own next prompt. Snyk reports that shape as W012 (MEDIUM) on the antislop listing.

v3.0.1 took the block out of the packaged skill, but by rewriting it during the sync:

```js
if (coreBody.includes('4. **Download the chosen skill(s)**')) {
  coreBody = coreBody.replace(
    /4\. \*\*Download the chosen skill\(s\)\*\*[\s\S]*?\n   ```\n(?=5\. )/,
    NO_DOWNLOAD_STEP + '\n\n'
  )
```

`antislop.md` is the file that block is generated from, and it kept the curl lines, pinned to v3.0.2. So the one-file door (`curl -o antislop.md`, the install README documents) still ships the downloads, and the regex only hides them from the packaged copy.

Before, on `main`:

```
$ git grep -c raw.githubusercontent -- antislop.md
antislop.md:5
```

After:

```
$ grep -rn raw.githubusercontent skills/ cli/skills/ antislop.md; echo "exit=$?"
exit=1
$ cd cli && node scripts/smoke-test.mjs
core SKILL.md exists: true
```

What changed:

- Step 4 hands the install back to the user: `npx antislop-ai`, `npx skills add miqdadbadjuber/anti-slop`, or, with no terminal, paste `skills/<name>/SKILL.md` out of the repo. The advice to take files from the tag matching the core stays.
- The wizard note now says it needs file-write access for step 5 only, and no network.
- `sync-skills.mjs` drops the rewrite and throws when a raw.githubusercontent URL reappears in the core, so a future edit cannot put it back quietly.
- `skills/antislop/SKILL.md` regenerated from the new source.

Left alone: `curl -o antislop.md` in README and guide.md. That is a person fetching a doc, not an agent fetching its own instructions.

The listing's current finding quotes v3.0.0 URLs, which are already gone from `main`, so it is scanning an old snapshot. This removes the last copy of the pattern in the repo, which should keep a re-audit clean.
