### PR TITLE
fix(skills): comma-separate allowed-tools so Claude Code can parse it

### DIFF
--- a/cli/scripts/sync-skills.mjs
+++ b/cli/scripts/sync-skills.mjs
@@ -11,7 +11,7 @@ const CORE_FRONTMATTER = [
   '---',
   'name: antislop',
   'description: "Anti Slop: Rules for AI Coding Agents. The core filter. Load always to stop generic AI slop."',
-  'allowed-tools: Read Write Edit Glob Grep',
+  'allowed-tools: Read, Write, Edit, Glob, Grep',
   '---',
   '',
 ].join('\n')

--- a/skills/antislop-code/SKILL.md
+++ b/skills/antislop-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-code
 description: "Code comment hygiene for AI coding agents: remove generic AI-slop comments, keep the valuable ones, never touch the code."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 # antislop-code
 

--- a/skills/antislop-copywriting/SKILL.md
+++ b/skills/antislop-copywriting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-copywriting
 description: "Copy and text skill for antislop. Use when writing or editing prose: headlines, tone, CTAs, and anti-AI-writing patterns. Load with the core."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 # antislop-copywriting
 

--- a/skills/antislop-human/SKILL.md
+++ b/skills/antislop-human/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-human
 description: "Human and accessibility skill for antislop. Contrast, keyboard, focus, and states for real people. Includes the contrast checker."
-allowed-tools: Bash(python *) Bash(python3 *) Read Write Edit Glob Grep
+allowed-tools: Bash(python *), Bash(python3 *), Read, Write, Edit, Glob, Grep
 ---
 # antislop-human
 

--- a/skills/antislop-layoutmobile/SKILL.md
+++ b/skills/antislop-layoutmobile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-layoutmobile
 description: "Mobile layout skill for antislop. Use for layouts that reflow on small screens: grids, overflow, tap targets. Load with the core."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 # antislop-layoutmobile
 

--- a/skills/antislop-ui/SKILL.md
+++ b/skills/antislop-ui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop-ui
 description: "UI and visual skill for antislop. Use when building or editing any interface: color, layout, components, motion. Load with the core."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 # antislop-ui
 

--- a/skills/antislop/SKILL.md
+++ b/skills/antislop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antislop
 description: "Anti Slop: Rules for AI Coding Agents. The core filter. Load always to stop generic AI slop."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 # antislop
 


### PR DESCRIPTION
Claude Code parses a skill's `allowed-tools` frontmatter as a **comma-separated** list. All six skills declare it space-separated, so the whole string is read as one tool name, matches nothing, and the skill can end up running with an effectively empty allowlist. Discovery is unaffected — the skills list and load fine — which is what makes it easy to miss.

`antislop-human` is where it actually bites: it ships `contrast-check.py` and declares `Bash(python *) Bash(python3 *)`, so the contrast checker is the first thing to fail.

The change is one line per skill:

```diff
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
```

`cli/scripts/sync-skills.mjs` writes the core skill's frontmatter from a constant, so it is fixed here too — otherwise the next `sync-skills` run puts the space-separated line back into `skills/antislop/SKILL.md`.

No content changes, no reformatting: 7 files, 7 lines.

Found while installing antislop into a Tauri + React project for both Claude Code and Codex.
