### PR TITLE
fix(plugin): pick the Python name at runtime instead of hardcoding one

### DIFF
--- a/.claude-plugin/contrast-mcp-launcher.mjs
+++ b/.claude-plugin/contrast-mcp-launcher.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Starts contrast-mcp.py with whichever Python name this machine actually has.
+ *
+ * The manifest's `command` is one string with no shell, so it cannot pick per
+ * platform on its own, and every single-name answer breaks somewhere: macOS has
+ * had no `python` since 12.3 removed Python 2, and Windows has no `python3` on
+ * some installs. v3.0.2 made allowed-tools and the skill prose accept both; this
+ * is the same fix for the one place that only takes a single value.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const server = path.join(here, "..", "skills", "antislop-human", "contrast-mcp.py");
+
+const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
+
+// Run each candidate rather than just looking it up: Windows ships a `python`
+// stub that exists on PATH and only opens the Store page, and pyenv leaves
+// shims that exit non-zero when no version is selected.
+const python = candidates.find(
+  (bin) => spawnSync(bin, ["-c", ""], { stdio: "ignore" }).status === 0
+);
+
+if (!python) {
+  // stderr, never stdout: stdout is the JSON-RPC channel.
+  console.error(
+    `antislop-contrast: no working Python found (tried ${candidates.join(", ")}). ` +
+      "Install Python 3 to use the contrast tool."
+  );
+  process.exit(1);
+}
+
+const child = spawn(python, [server], { stdio: "inherit" });
+child.on("exit", (code, signal) => process.exit(signal ? 1 : (code ?? 0)));

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,8 +12,8 @@
   "skills": ["./skills/"],
   "mcpServers": {
     "antislop-contrast": {
-      "command": "python",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/skills/antislop-human/contrast-mcp.py"],
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/.claude-plugin/contrast-mcp-launcher.mjs"],
       "env": {}
     }
   }


### PR DESCRIPTION
Fixes #19.

I filed that issue proposing `python3` in the manifest, then checked the history and found you had already tried that and moved back on purpose:

```
2f5a5ad  v3.0.0   created as        "python"
38f812d  #11      python  -> python3
3574047  v3.0.2   python3 -> python
```

v3.0.2 is the "adaptive python" release, and it did the adaptive thing in both places that accept two names: `allowed-tools` became `Bash(python *) Bash(python3 *)`, and the skill prose became "python3 on macOS and Linux, python on Windows". The manifest went back to `python` because `command` takes exactly one value. So the issue as I wrote it had the reasoning backwards, and I have corrected it there.

This PR gives that single value the same adaptive answer instead of picking a side. `command` becomes `node`, pointing at a 25-line launcher that chooses the Python name at runtime.

It runs each candidate rather than only checking PATH, because two common setups have a `python` that exists and does not work: the Windows Store stub that opens a store page, and a pyenv shim with no version selected.

The launcher sits in `.claude-plugin/` rather than the skill folder, so it ships with the plugin and does not get copied into every project by the picker. `files` in `cli/package.json` is unchanged, so it stays out of the npm payload too.

## Verified

Normal PATH:

```console
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
    | node .claude-plugin/contrast-mcp-launcher.mjs
{"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
 "serverInfo": {"name": "antislop-contrast", "version": "3.2.5"}}}
```

A stock macOS PATH, where `python` does not exist at all:

```console
$ env PATH=/usr/bin:/bin:/usr/sbin:/sbin:$NODEDIR sh -c 'command -v python || echo "python: absent"'
python: absent

$ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"check_contrast",
  "arguments":{"foreground":"#777777","background":"#FFFFFF"}}}' \
    | env PATH=/usr/bin:/bin:/usr/sbin:/sbin:$NODEDIR node .claude-plugin/contrast-mcp-launcher.mjs
{"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text":
 "{\"ratio\": 4.48, \"normal_text\": {\"threshold\": 4.5, \"pass\": false},
   \"large_text\": {\"threshold\": 3.0, \"pass\": true}}"}], "isError": false}}
```

That 4.48 is the same figure as the contrast table row from #2, so the tool is answering, not just starting.

No Python at all, which should fail loudly on stderr and never on stdout:

```console
$ ... | node .claude-plugin/contrast-mcp-launcher.mjs
antislop-contrast: no working Python found (tried python3, python). Install Python 3 to use the contrast tool.
exit: 1
```

I do not have a Windows machine, so the win32 branch is reasoned, not run. If you would rather not carry a launcher at all, the smaller alternative is to leave `command` as `python` and say plainly in SECURITY.md that the MCP tool is Windows-only, since the skill's own `contrast-check.py` path still works everywhere. I think the launcher is the better trade, but it is your call.
