### PR TITLE
fix(cli): keep the entry file the user wrote, outside the pointer block

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The report notes that antislop appends a pointer block to an agent entry file su
 
 - is a static markdown reference. It lists the installed skills and carries no executable content.
 - is written only after you approve. The picker and the manual wizard both ask first.
-- is appended at the end of the entry file. Existing content is never changed.
+- is added at the end of the entry file on a first install, and replaced where it already sits on later runs. Nothing else in the file is touched, including your own blank lines and code blocks.
 - lives in [cli/lib/install.mjs](cli/lib/install.mjs) for the picker, and in the wizard inside [antislop.md](antislop.md) for the manual path.
 
 Removing this behavior would remove the core promise: a filter that is always on, not one you remember to invoke. Any always-on ruleset that writes a reference to an entry file matches this pattern.

--- a/cli/lib/install.mjs
+++ b/cli/lib/install.mjs
@@ -141,12 +141,17 @@ function writeBlock(entry, block) {
   const start = lines.findIndex((l) => l.trim() === POINTER_START)
   const end = lines.findIndex((l) => l.trim() === POINTER_END)
   const replacing = start !== -1 && end !== -1 && start < end
-  const head = replacing ? lines.slice(0, start) : lines
+  const head = replacing ? lines.slice(0, start) : lines.slice()
   const tail = replacing ? lines.slice(end + 1) : []
 
-  const body = [...head, '', ...block, '', ...tail]
+  // Tidy the two seams only. Normalising the joined document, which is what a
+  // /\n{3,}/g sweep does, also collapses blank lines the author wrote, including
+  // the ones inside their fenced code blocks.
+  while (head.length && head[head.length - 1].trim() === '') head.pop()
+  while (tail.length && tail[0].trim() === '') tail.shift()
+
+  const body = [...head, '', ...block, ...(tail.length ? ['', ...tail] : [])]
     .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
     .replace(/^\n+/, '')
     .trimEnd()
 


### PR DESCRIPTION
Fixes #20. Two files: `cli/lib/install.mjs` and one line of `SECURITY.md`.

`writeBlock` rebuilt the whole document and ran `/\n{3,}/g` over the result, so every run of two or more blank lines in the user's entry file collapsed to one, code fences included. The sweep was only needed to stop a gap forming at the splice, so this trims the two seams and leaves everything else as written.

## Verified

An entry file with blank lines the author meant to keep, one pair inside a fence:

````console
$ cat CLAUDE.md
# House rules

```text
before


after
```


Spaced out on purpose.
````

On `main`, both pairs collapse. With this branch the file comes back untouched and the block is appended:

````console
$ node -e "...updatePointers..." && cat CLAUDE.md
# House rules

```text
before


after
```


Spaced out on purpose.

<!-- antislop:start -->
## antislop
...
<!-- antislop:end -->
````

Comparing the author's own content byte for byte, with the block stripped out: `IDENTICAL`.

Three other cases still behave:

- **New entry file.** Produces the block alone, no leading blank line.
- **Reinstall.** Still exactly one block, no duplicate.
- **Block mid-file.** Replaced in place, with the sections above and below intact.

`node scripts/smoke-test.mjs` still matches every printed expectation, including `B pointers: CLAUDE.md`, `D antigravity pointers: AGENTS.md` and `D2 gemini pointer: GEMINI.md`.

## The SECURITY.md line

That page answered the Trust Hub finding with "is appended at the end of the entry file. Existing content is never changed." Neither half was accurate: the block is replaced in place when one exists, and content was being changed. It now describes what the code does, which is still a good answer to the finding and has the advantage of being checkable.

Once #21 lands, the blank-line case is worth an assert in the smoke test so it cannot come back. I kept that out of here to keep the two changes separable.
