### PR TITLE
test(cli): make the smoke test able to fail

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,6 +30,7 @@
     "skills/"
   ],
   "scripts": {
+    "test": "node scripts/smoke-test.mjs",
     "sync-skills": "node scripts/sync-skills.mjs",
     "prepublishOnly": "npm run sync-skills"
   },

--- a/cli/scripts/smoke-test.mjs
+++ b/cli/scripts/smoke-test.mjs
@@ -26,7 +26,7 @@ const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'antislop-smoke-'))
 const result = spawnSync(process.execPath, [worker], { cwd: tmp, encoding: 'utf8' })
 console.log('--- worker output ---')
 console.log(result.stdout.trim())
-if (result.status !== 0) console.log('worker stderr:', result.stderr)
+if (result.status !== 0) console.error('worker stderr:', result.stderr)
 
 console.log('\n--- files written to temp project ---')
 console.log(tree(tmp).join('\n'))
@@ -39,7 +39,19 @@ for (const name of ['CLAUDE.md', 'AGENTS.md', 'GEMINI.md']) {
 }
 
 const coreSkill = path.join(tmp, '.claude', 'skills', 'antislop', 'SKILL.md')
-console.log('\ncore SKILL.md exists:', fs.existsSync(coreSkill))
+const coreInstalled = fs.existsSync(coreSkill)
+console.log('\ncore SKILL.md exists:', coreInstalled)
+
+// Decide before cleaning up, so a failure still leaves a tidy temp dir behind.
+const reasons = []
+if (result.status !== 0) reasons.push(`worker exited ${result.status}`)
+if (!coreInstalled) reasons.push('core SKILL.md was not installed')
 
 fs.rmSync(tmp, { recursive: true, force: true })
 console.log('\ncleaned up temp project.')
+
+if (reasons.length > 0) {
+  console.error('\nsmoke test failed: ' + reasons.join('; '))
+  process.exit(1)
+}
+console.log('smoke test passed.')

--- a/cli/scripts/smoke-worker.mjs
+++ b/cli/scripts/smoke-worker.mjs
@@ -12,9 +12,22 @@ import {
 
 const skills = ['antislop', 'antislop-ui']
 
+const failures = []
+
+/**
+ * Prints the line the script always printed, and remembers whether it held.
+ * Collecting instead of throwing means one run reports every break, not only
+ * the first, which is what you want from a smoke test you run after a refactor.
+ */
+const check = (label, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected)
+  console.log(ok ? `ok   ${label}:` : `FAIL ${label}:`, actual, ok ? '' : `(expected ${JSON.stringify(expected)})`)
+  if (!ok) failures.push(label)
+}
+
 // 1. Fresh state: nothing detected, and the default selection is every agent.
 const fresh = detectAgents('project')
-console.log('A detected (fresh project):', fresh.length === 0 ? 'none' : fresh.join(', '), '(expect none)')
+check('A detected (fresh project)', fresh, [])
 const defaultTargets = resolveTargets('project')
 console.log('A default targets:', defaultTargets.map((t) => `${t.agent.id}@${t.path} exists=${t.exists}`).join(' | '), '(expect all seven, exists=false)')
 
@@ -24,24 +37,24 @@ let written = installSkills({ skills, targets, overwrite: false })
 let pointers = updatePointers({ targets, skills })
 console.log('B targets:', targets.map((t) => `${t.agent.id}@${t.path} exists=${t.exists}`).join(' | '))
 console.log('B written:', written.map((w) => `${w.agent.id}:${w.skill}`).join(', '))
-console.log('B pointers:', pointers.map((p) => path.basename(p)).join(', '), '(expect CLAUDE.md)')
+check('B pointers', pointers.map((p) => path.basename(p)), ['CLAUDE.md'])
 
 const conflicts = detectConflicts({ skills, targets })
 written = installSkills({ skills, targets, overwrite: false })
-console.log('C conflicts:', conflicts.length, '(expect 2)')
-console.log('C written:', written.length, '(expect 0)')
+check('C conflicts', conflicts.length, 2)
+check('C written without overwrite', written.length, 0)
 written = installSkills({ skills, targets, overwrite: true })
-console.log('C overwritten:', written.length, '(expect 2)')
+check('C overwritten', written.length, 2)
 
 // 3. Antigravity on the fresh project: the reported bug. The target is included
 //    even though .agents/ did not exist, install creates it, pointer goes to AGENTS.md.
 const agTargets = resolveTargets('project', ['antigravity'])
 console.log('D antigravity targets:', agTargets.map((t) => `${t.agent.id}@${t.path} exists=${t.exists}`).join(' | '), '(exists=false before install)')
 const agWritten = installSkills({ skills, targets: agTargets, overwrite: false })
-console.log('D antigravity written:', agWritten.map((w) => `${w.agent.id}:${w.skill}`).join(', '), '(expect 2)')
+check('D antigravity written', agWritten.length, 2)
 const agPointers = updatePointers({ targets: agTargets, skills })
-console.log('D antigravity pointers:', agPointers.map((p) => path.basename(p)).join(', '), '(expect AGENTS.md)')
-console.log('D .agents/skills/antislop/SKILL.md exists:', fs.existsSync(path.join(process.cwd(), '.agents', 'skills', 'antislop', 'SKILL.md')))
+check('D antigravity pointers', agPointers.map((p) => path.basename(p)), ['AGENTS.md'])
+check('D .agents/skills/antislop/SKILL.md exists', fs.existsSync(path.join(process.cwd(), '.agents', 'skills', 'antislop', 'SKILL.md')), true)
 
 // 4. New providers on the fresh project: OpenCode, Cursor, Gemini install and
 //    point to their own entry files.
@@ -49,22 +62,22 @@ for (const agent of ['opencode', 'cursor', 'gemini']) {
   const t = resolveTargets('project', [agent])
   const w = installSkills({ skills, targets: t, overwrite: false })
   const pointers = updatePointers({ targets: t, skills })
-  console.log(`D2 ${agent} written:`, w.map((x) => `${x.agent.id}:${x.skill}`).join(', '), '(expect 2)')
-  console.log(`D2 ${agent} pointer:`, pointers.map((p) => path.basename(p)).join(', '), `(expect ${agent === 'gemini' ? 'GEMINI.md' : 'AGENTS.md'})`)
-  console.log(`D2 ${agent} folder exists:`, fs.existsSync(path.join(process.cwd(), agent === 'gemini' ? '.gemini' : agent === 'cursor' ? '.cursor' : '.opencode', 'skills', 'antislop', 'SKILL.md')))
+  check(`D2 ${agent} written`, w.length, 2)
+  check(`D2 ${agent} pointer`, pointers.map((p) => path.basename(p)), [agent === 'gemini' ? 'GEMINI.md' : 'AGENTS.md'])
+  check(`D2 ${agent} folder exists`, fs.existsSync(path.join(process.cwd(), agent === 'gemini' ? '.gemini' : agent === 'cursor' ? '.cursor' : '.opencode', 'skills', 'antislop', 'SKILL.md')), true)
 }
 
 // 5. Hermes is global-only: even a project install resolves to the home dir, and
 //    it is never detected as a project agent. resolveTargets only, no install.
 const hermesProject = resolveTargets('project', ['hermes'])
 const hermesGlobal = resolveTargets('global', ['hermes'])
-console.log('D3 hermes project target:', hermesProject[0].path, '(expect ' + path.join(os.homedir(), '.hermes', 'skills') + ')')
-console.log('D3 hermes global target:', hermesGlobal[0].path, '(expect ' + path.join(os.homedir(), '.hermes', 'skills') + ')')
-console.log('D3 hermes detected in project:', detectAgents('project').includes('hermes'), '(expect false)')
+check('D3 hermes project target', hermesProject[0].path, path.join(os.homedir(), '.hermes', 'skills'))
+check('D3 hermes global target', hermesGlobal[0].path, path.join(os.homedir(), '.hermes', 'skills'))
+check('D3 hermes detected in project', detectAgents('project').includes('hermes'), false)
 
 // 6. Detection now sees the agents that were installed.
 const after = detectAgents('project')
-console.log('E detected after installs:', after.join(', '), '(expect claude, antigravity, opencode, cursor, gemini)')
+check('E detected after installs', [...after].sort(), ['antigravity', 'claude', 'cursor', 'gemini', 'opencode'])
 
 // 7. Global with a selection.
 const globalTargets = resolveTargets('global', ['claude', 'codex'])
@@ -73,8 +86,14 @@ console.log('F global targets:', globalTargets.map((t) => `${t.agent.id}@${t.pat
 // 8. Copies are identical and the pointer block dedupes.
 const src = fs.readFileSync(path.join(skillSourceDir(), 'antislop-ui', 'SKILL.md'), 'utf8')
 const dst = fs.readFileSync(path.join(process.cwd(), '.claude', 'skills', 'antislop-ui', 'SKILL.md'), 'utf8')
-console.log('G antislop-ui SKILL.md identical:', src === dst)
+check('G antislop-ui SKILL.md identical', src === dst, true)
 
 updatePointers({ targets, skills })
 const entry = fs.readFileSync(path.join(process.cwd(), 'CLAUDE.md'), 'utf8')
-console.log('H blocks after a second run:', (entry.match(/antislop:start/g) || []).length, '(expect 1)')
+check('H blocks after a second run', (entry.match(/antislop:start/g) || []).length, 1)
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} check(s) failed: ${failures.join(', ')}`)
+  process.exit(1)
+}
+console.log('\nall checks passed')


### PR DESCRIPTION
Fixes #21. No behavior in the installer changes, only whether a break is noticed.

The 17 lines that already stated an expectation become a `check()` that prints the same information, compares, and records. It collects rather than throws, so one run reports every break instead of stopping at the first.

## Verified

Healthy tree, 23 checks:

```console
$ npm test
ok   A detected (fresh project): []
ok   B pointers: [ 'CLAUDE.md' ]
ok   C conflicts: 2
ok   C written without overwrite: 0
ok   C overwritten: 2
...
ok   D2 gemini pointer: [ 'GEMINI.md' ]
ok   E detected after installs: [ 'antigravity', 'claude', 'cursor', 'gemini', 'opencode' ]
ok   G antislop-ui SKILL.md identical: true
ok   H blocks after a second run: 1

all checks passed
smoke test passed.
EXIT: 0
```

The case from the issue, a worker that dies before installing anything:

```console
$ npm test
core SKILL.md exists: false
smoke test failed: worker exited 1; core SKILL.md was not installed
EXIT: 1
```

And a real logic regression rather than a crash. Changing `ENTRY_FILE.gemini` to `AGENTS.md`, the kind of edit that would previously have shipped:

```console
$ npm test
FAIL D2 gemini pointer: [ 'AGENTS.md' ] (expected ["GEMINI.md"])
1 check(s) failed: D2 gemini pointer
smoke test failed: worker exited 1
EXIT: 1
```

Both faults reverted, back to `EXIT: 0`.

## Notes

- `"test": "node scripts/smoke-test.mjs"` had no entry in `cli/package.json` before, so there was nothing for CI or a contributor to call.
- The runner decides pass or fail before `fs.rmSync`, so a failing run still cleans up its temp project.
- Worker stderr moved from `console.log` to `console.error`, since it is an error channel.
- Comparison is `JSON.stringify` on both sides, which is enough for the strings, numbers, booleans and short arrays these checks hold. `E detected after installs` is sorted before comparing, because agent detection order is filesystem order and was never guaranteed.

If you want this running on PRs, the workflow is three lines calling `npm test`, `python3 skills/antislop-human/contrast-check.py --selftest`, and `node cli/scripts/sync-skills.mjs && git diff --exit-code skills/` to catch `antislop.md` edits that were never synced. Happy to send that separately if you want CI here; I did not add `.github/` in this PR since that is a bigger call than a test fix.
