### PR TITLE
ci: run the checks this repo already had, plus the ones its own rules imply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # The rules antislop applies to other repos, applied to this one: the em
+      # dash ban with its own carve-out, rule and gate coverage, version drift,
+      # manifest validity, skill registration.
+      - name: Repo guardrails
+        run: node scripts/check-repo.mjs
+
+      # The contrast table in antislop-human is a set of claims about a formula.
+      # This recomputes every row. It caught issue #2 by hand once already.
+      - name: Contrast table matches the formula
+        run: python3 skills/antislop-human/contrast-check.py --selftest
+
+      # skills/antislop/SKILL.md is generated from antislop.md. Editing the core
+      # and not syncing ships a skill that disagrees with the file it came from.
+      # sync-skills also throws on a raw.githubusercontent URL in the core, which
+      # is the Snyk W012 guard from v3.0.1.
+      - name: Generated core skill is in sync with antislop.md
+        run: |
+          node cli/scripts/sync-skills.mjs
+          git diff --exit-code -- skills/
+
+      - name: Installer smoke test
+        run: node cli/scripts/smoke-test.mjs

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ The two usage modes: DURING applies the rules while building, AFTER audits finis
 
 Found a new AI slop pattern, a rule that missed something, or a bug in the installer? Open an [issue](https://github.com/miqdadbadjuber/anti-slop/issues). PRs are welcome for new AI slop patterns, clarifications, or checklist items out of sync with their rule.
 
+Before pushing, run the checks CI runs. They need no install step:
+
+```bash
+node scripts/check-repo.mjs          # em dashes, rule and gate coverage, versions, links
+node cli/scripts/smoke-test.mjs      # the installer, end to end
+python3 skills/antislop-human/contrast-check.py --selftest
+```
+
+Editing `antislop.md` also means running `node cli/scripts/sync-skills.mjs`, because `skills/antislop/SKILL.md` is generated from it and CI fails on the drift.
+
 ## License
 
 MIT: [LICENSE](LICENSE)

--- a/scripts/check-repo.mjs
+++ b/scripts/check-repo.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * The rules antislop applies to other people's repos, applied to this one.
+ *
+ * Every check here exists because the matching mistake already shipped: a gate
+ * item that disagreed with its rule (#7), checklists whose polarity no item used
+ * (#9), a contrast row that was wrong (#2), and the repo not passing its own
+ * filter (#6). Run it before opening a PR:
+ *
+ *   node scripts/check-repo.mjs
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const read = (p) => fs.readFileSync(path.join(root, p), 'utf8')
+const lines = (p) => read(p).split('\n')
+
+const SKILLS = fs
+  .readdirSync(path.join(root, 'skills'), { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => `skills/${e.name}/SKILL.md`)
+
+const MANIFESTS = [
+  '.claude-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
+  '.codex-plugin/plugin.json',
+  '.cursor-plugin/plugin.json',
+  '.cursor-plugin/marketplace.json',
+  '.agents/plugins/marketplace.json',
+  'plugin.json',
+  'cli/package.json',
+]
+
+/**
+ * R-02 bans the em dash, and R-02's own carve-out exempts the places that have
+ * to name the character to ban it. Encode that carve-out rather than skipping
+ * the check, so a new em dash in ordinary prose still fails.
+ */
+function emDashes() {
+  const bad = []
+  const files = ['antislop.md', 'README.md', 'GUIDE.md', 'ROADMAP.md', 'SECURITY.md', ...SKILLS]
+
+  for (const file of files) {
+    let section = ''
+    lines(file).forEach((line, i) => {
+      const heading = line.match(/^#{2,4}\s+(.*)$/)
+      if (heading) section = heading[1]
+      if (!/[—–]/.test(line)) return
+
+      const exempt =
+        // "#### R-02 — Copywriting" and "### C-1 — Intentionality"
+        /^#{2,4}\s+(R-\d{2}|C-\d)\s+—\s/.test(line) ||
+        // The rule that defines the ban, and the skill section that teaches it.
+        /^(R-02|Em Dashes)\b/.test(section) ||
+        // The Part 1 table row that shows the pattern.
+        /^\|\s*\*\*Em Dash/.test(line) ||
+        // The Delivery Gate item that quotes the character it checks for.
+        (/^\s*- \[ \]/.test(line) && /\*\(R-02\)\*/.test(line))
+
+      if (!exempt) bad.push(`${file}:${i + 1}: ${line.trim().slice(0, 90)}`)
+    })
+  }
+  return bad
+}
+
+/** Every rule the core defines must have a Delivery Gate item citing it, and vice versa. */
+function gateCoverage() {
+  const core = read('antislop.md')
+  const defined = new Set([...core.matchAll(/^#### (R-\d{2}) —/gm)].map((m) => m[1]))
+  const gate = core.split('## Delivery Gate (Mandatory)')[1] ?? ''
+  const cited = new Set([...gate.matchAll(/\((R-\d{2})\)/g)].map((m) => m[1]))
+
+  const bad = []
+  for (const r of [...defined].sort()) {
+    if (!cited.has(r)) bad.push(`${r} is defined in Part 2 but no Delivery Gate item cites it`)
+  }
+  for (const r of [...cited].sort()) {
+    if (!defined.has(r)) bad.push(`${r} is cited in the Delivery Gate but Part 2 does not define it`)
+  }
+  return bad
+}
+
+/** A skill may reference core rules by number. It may not invent one. */
+function skillReferences() {
+  const defined = new Set([...read('antislop.md').matchAll(/^#### (R-\d{2}) —/gm)].map((m) => m[1]))
+  const bad = []
+  for (const file of SKILLS) {
+    for (const r of new Set([...read(file).matchAll(/\bR-\d{2}\b/g)].map((m) => m[0]))) {
+      if (!defined.has(r)) bad.push(`${file} cites ${r}, which antislop.md does not define`)
+    }
+  }
+  return bad
+}
+
+/** The version is hand-written in eight places. They have to agree. */
+function versions() {
+  // A file that does not parse is already reported by the manifest check, so
+  // read it leniently here rather than crashing the whole run on it.
+  const json = (p) => {
+    try {
+      return JSON.parse(read(p))
+    } catch {
+      return null
+    }
+  }
+  const want = json('cli/package.json')?.version
+  if (!want) return ['cli/package.json has no readable version']
+
+  const found = [
+    ['.claude-plugin/plugin.json', json('.claude-plugin/plugin.json')?.version],
+    ['.claude-plugin/marketplace.json', json('.claude-plugin/marketplace.json')?.plugins?.[0]?.version],
+    ['.codex-plugin/plugin.json', json('.codex-plugin/plugin.json')?.version],
+    ['.cursor-plugin/plugin.json', json('.cursor-plugin/plugin.json')?.version],
+    ['cli/index.mjs', read('cli/index.mjs').match(/antislop (\d+\.\d+\.\d+)/)?.[1]],
+    ['cli/lib/banner.mjs', read('cli/lib/banner.mjs').match(/installer v(\d+\.\d+\.\d+)/)?.[1]],
+    ['skills/antislop-human/contrast-mcp.py', read('skills/antislop-human/contrast-mcp.py').match(/SERVER_VERSION = "(\d+\.\d+\.\d+)"/)?.[1]],
+  ]
+
+  return found
+    .filter(([, got]) => got !== want)
+    .map(([file, got]) => `${file} says ${got ?? 'nothing'}, cli/package.json says ${want}`)
+}
+
+/** A manifest that does not parse takes its whole install path down. */
+function manifests() {
+  const bad = []
+  for (const file of MANIFESTS) {
+    try {
+      JSON.parse(read(file))
+    } catch (err) {
+      bad.push(`${file} is not valid JSON: ${err.message}`)
+    }
+  }
+  return bad
+}
+
+/** An agent finds a skill by its frontmatter. Without it the folder is inert. */
+function frontmatter() {
+  const bad = []
+  for (const file of SKILLS) {
+    const head = read(file).split('---')[1] ?? ''
+    // [ \t] not \s: \s spans the newline, so an empty value matches the first
+    // character of the next key and every skill passes.
+    if (!/^name:[ \t]*\S/m.test(head)) bad.push(`${file} has no name in its frontmatter`)
+    if (!/^description:[ \t]*\S/m.test(head)) bad.push(`${file} has no description in its frontmatter`)
+  }
+  return bad
+}
+
+/**
+ * A new skill folder has to be registered in four other places before anyone can
+ * install it: both rule pointers, the picker's menu, and the pointer block the
+ * picker writes. v3.1.0 had to touch all four to ship antislop-code.
+ */
+function registration() {
+  const names = SKILLS.map((f) => f.split('/')[1])
+  const core = 'antislop'
+  const places = [
+    ['rules/antislop.md', read('rules/antislop.md')],
+    ['rules/antislop.mdc', read('rules/antislop.mdc')],
+    ["cli/index.mjs (EXTRA_SKILLS)", read('cli/index.mjs')],
+    ['cli/lib/install.mjs (SKILL_LINES)', read('cli/lib/install.mjs')],
+  ]
+
+  const bad = []
+  for (const name of names) {
+    for (const [label, text] of places) {
+      // The core is always on, so the picker's optional-extras menu never lists it.
+      if (name === core && label.startsWith('cli/index.mjs')) continue
+      if (!text.includes(name)) bad.push(`${name} is not registered in ${label}`)
+    }
+  }
+  return bad
+}
+
+const CHECKS = [
+  // Manifests first: the later checks read them as data.
+  ['every manifest is valid JSON', manifests],
+  ['no em dash outside the R-02 carve-out', emDashes],
+  ['every rule has a Delivery Gate item', gateCoverage],
+  ['skills cite only rules that exist', skillReferences],
+  ['the version agrees everywhere', versions],
+  ['every skill has usable frontmatter', frontmatter],
+  ['every skill is registered everywhere', registration],
+]
+
+let failed = 0
+for (const [label, run] of CHECKS) {
+  const problems = run()
+  if (problems.length === 0) {
+    console.log(`ok   ${label}`)
+    continue
+  }
+  failed += 1
+  console.log(`FAIL ${label}`)
+  for (const p of problems) console.log(`       ${p}`)
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} of ${CHECKS.length} checks failed`)
+  process.exit(1)
+}
+console.log(`\nall ${CHECKS.length} checks passed`)

--- a/scripts/check-repo.mjs
+++ b/scripts/check-repo.mjs
@@ -175,6 +175,106 @@ function registration() {
   return bad
 }
 
+/**
+ * A rule's tier decides which Delivery Gate block it belongs in: Hard Gate to
+ * Block 1, Purpose-Gate to Block 2, Quality Locks to Block 4. A rule cited from
+ * the wrong block is what #7 was, three gate items disagreeing with their rule.
+ */
+function tiers() {
+  const core = read('antislop.md')
+  const part2 = core.split('## Part 2:')[1]?.split('## Part 3:')[0] ?? ''
+
+  const group = {}
+  let current = null
+  for (const line of part2.split('\n')) {
+    const g = line.match(/^### Group \d: ([^(]+)/)
+    if (g) current = g[1].trim()
+    const r = line.match(/^#### (R-\d{2}) —/)
+    if (r && current) group[r[1]] = current
+  }
+
+  const block = {}
+  let currentBlock = null
+  for (const line of (core.split('## Delivery Gate (Mandatory)')[1] ?? '').split('\n')) {
+    const b = line.match(/^### (Block \d):/)
+    if (b) currentBlock = b[1]
+    for (const m of line.matchAll(/\((R-\d{2})\)/g)) {
+      if (!block[m[1]]) block[m[1]] = currentBlock
+    }
+  }
+
+  const wants = { 'Hard Gate': 'Block 1', 'Purpose-Gate': 'Block 2', 'Quality Locks': 'Block 4' }
+  const bad = []
+  for (const [rule, grp] of Object.entries(group).sort()) {
+    const want = wants[grp]
+    const got = block[rule]
+    if (want && got && want !== got) bad.push(`${rule} is a ${grp} rule but the gate cites it from ${got}`)
+  }
+  return bad
+}
+
+/** A manifest that points at a file that is gone breaks its install path quietly. */
+function manifestPaths() {
+  const bad = []
+  for (const file of MANIFESTS) {
+    let text
+    try {
+      text = read(file)
+    } catch {
+      continue
+    }
+    for (const m of text.matchAll(/"(\.\/[^"]+)"/g)) {
+      const target = m[1].replace(/^\.\//, '')
+      if (!existsExactly(target)) bad.push(`${file} points at ${m[1]}, which does not exist`)
+    }
+  }
+  return bad
+}
+
+/**
+ * A rename like guide.md to GUIDE.md in v3.2.4 is exactly when a doc link goes
+ * stale, and existsSync cannot see it: macOS is case-insensitive, so the old
+ * link keeps passing locally and only breaks for readers on github.com. Compare
+ * against the real directory entry instead.
+ */
+const existsExactly = (target) => {
+  const full = path.join(root, target)
+  const dir = path.dirname(full)
+  if (!fs.existsSync(dir)) return false
+  return fs.readdirSync(dir).includes(path.basename(full))
+}
+
+function docLinks() {
+  const bad = []
+  for (const file of ['README.md', 'GUIDE.md', 'ROADMAP.md', 'SECURITY.md']) {
+    for (const m of read(file).matchAll(/\]\(([^)\s]+)\)/g)) {
+      const target = m[1].split('#')[0]
+      if (!target || /^(https?:|mailto:)/.test(target)) continue
+      if (!existsExactly(target)) bad.push(`${file} links to ${target}, which does not exist`)
+    }
+  }
+  return bad
+}
+
+/**
+ * contrast-check.py and contrast-mcp.py each carry their own copy of the WCAG
+ * formula, and only the first has a selftest. The plugin exposes the second, so
+ * a drift between them would ship as a wrong answer with nothing to catch it.
+ */
+function contrastTwins() {
+  const check = read('skills/antislop-human/contrast-check.py')
+  const mcp = read('skills/antislop-human/contrast-mcp.py')
+  const constants = ['0.03928', '12.92', '1.055', '0.2126', '0.7152', '0.0722', '0.05']
+
+  const bad = []
+  for (const c of constants) {
+    if (check.includes(c) !== mcp.includes(c)) {
+      bad.push(`the WCAG constant ${c} appears in only one of contrast-check.py and contrast-mcp.py`)
+    }
+  }
+  return bad
+}
+
 const CHECKS = [
   // Manifests first: the later checks read them as data.
   ['every manifest is valid JSON', manifests],
@@ -184,6 +284,10 @@ const CHECKS = [
   ['the version agrees everywhere', versions],
   ['every skill has usable frontmatter', frontmatter],
   ['every skill is registered everywhere', registration],
+  ['each rule sits in the gate block its tier implies', tiers],
+  ['every manifest path resolves', manifestPaths],
+  ['every doc link resolves', docLinks],
+  ['both contrast implementations use the same formula', contrastTwins],
 ]
 
 let failed = 0


### PR DESCRIPTION
I said in #24 that adding `.github/` was your call, not something to send unasked. Here it is as a PR you can close if you disagree, rather than as a suggestion you have to act on.

The repo already had three things worth running and nothing running them: the smoke test, `contrast-check.py --selftest`, and the Snyk W012 guard that lives inside `sync-skills.mjs`. All three had to be remembered by hand.

## What the workflow runs

| step | catches |
| --- | --- |
| `node scripts/check-repo.mjs` | the seven repo-level checks below |
| `contrast-check.py --selftest` | a contrast table row that disagrees with the formula (#2) |
| `sync-skills.mjs` then `git diff --exit-code -- skills/` | an `antislop.md` edit never synced into the generated skill, and a `raw.githubusercontent` URL in the core (W012) |
| `cli/scripts/smoke-test.mjs` | installer regressions (#13, #15) |

The last one only bites once #24 lands, since the current script exits 0 whatever happens. I kept this PR independent of that one so there is no merge order to get right.

## The eleven checks

Each is here because the matching mistake already shipped in this repo:

- **no em dash outside the R-02 carve-out.** Not a blanket grep: it encodes the carve-out R-02 writes down, so `#### R-02 — Copywriting`, the Part 1 table row, the rule's own definition, the gate item quoting it, and the copywriting skill's `Em Dashes` section all pass, while a new em dash in ordinary prose fails. Relevant to #6, "antislop does not pass its own filter".
- **every rule has a Delivery Gate item**, and every gate citation has a rule. This is #7's class.
- **skills cite only rules that exist.** #9's class.
- **the version agrees** across the seven files that state one. Today that is `cli/package.json`, three plugin manifests, the marketplace entry, `cli/index.mjs`, `cli/lib/banner.mjs` and `contrast-mcp.py`.
- **every manifest parses.** A broken one silently takes its whole install path down.
- **every skill has a name and description**, or an agent never finds it.
- **every skill is registered** in `rules/antislop.md`, `rules/antislop.mdc`, the picker's `EXTRA_SKILLS` and `SKILL_LINES`. Those are the four places v3.1.0 had to touch to ship `antislop-code`.
- **each rule sits in the gate block its tier implies.** Hard Gate to Block 1, Purpose-Gate to Block 2, Quality Locks to Block 4. A rule cited from the wrong block is #7's other half.
- **every manifest path resolves.** `./assets/profile.png`, `./skills/`, `./rules/`.
- **every doc link resolves.** Compared against the real directory entry, not `existsSync`: macOS is case-insensitive, so after v3.2.4 renamed `guide.md` to `GUIDE.md` a stale lowercase link keeps passing on a Mac and breaks only for readers on github.com.
- **both contrast implementations use the same formula.** `contrast-check.py` and `contrast-mcp.py` each carry their own copy of the WCAG constants and only the first has a selftest, so the one the plugin exposes as a tool is the untested one.

## Verified by breaking each one

A check that has only ever passed is the defect I filed in #21, so I broke the thing each check guards:

```console
=== em dash in prose ===
FAIL no em dash outside the R-02 carve-out
       antislop.md:91: Removing slop reveals nothing — it leaves a void; ...
=== rule loses its gate item ===
FAIL every rule has a Delivery Gate item
       R-03 is defined in Part 2 but no Delivery Gate item cites it
=== skill cites a rule that does not exist ===
FAIL skills cite only rules that exist
       skills/antislop-ui/SKILL.md cites R-99, which antislop.md does not define
=== one version left behind ===
FAIL the version agrees everywhere
       cli/lib/banner.mjs says 3.2.4, cli/package.json says 3.2.5
=== manifest with a trailing comma ===
FAIL every manifest is valid JSON
       .cursor-plugin/plugin.json is not valid JSON: Expected double-quoted property name ...
=== skill with an empty description ===
FAIL every skill has usable frontmatter
       skills/antislop-code/SKILL.md has no description in its frontmatter
=== new skill folder, pointers not updated ===
FAIL every skill is registered everywhere
       antislop-docs is not registered in rules/antislop.md
       antislop-docs is not registered in rules/antislop.mdc
       antislop-docs is not registered in cli/index.mjs (EXTRA_SKILLS)
       antislop-docs is not registered in cli/lib/install.mjs (SKILL_LINES)
=== R-24 moved into the wrong gate block ===
FAIL each rule sits in the gate block its tier implies
       R-24 is a Hard Gate rule but the gate cites it from Block 4
=== manifest asset renamed ===
FAIL every manifest path resolves
       .codex-plugin/plugin.json points at ./assets/logo-that-was-renamed.png, which does not exist
=== README left pointing at the old lowercase guide.md ===
FAIL every doc link resolves
       README.md links to guide.md, which does not exist
=== one WCAG constant changed in contrast-mcp.py only ===
FAIL both contrast implementations use the same formula
       the WCAG constant 0.2126 appears in only one of contrast-check.py and contrast-mcp.py
```

Every fault exits 1, and the clean tree exits 0 on all eleven.

That exercise found three bugs in my own script, all fixed before this PR: an unparseable manifest crashed the version check before the manifest check could report it, `/^description:\s*\S/m` matched an empty description because `\s` spans the newline and landed on the next key's first character, and the doc link check passed a case-only rename on macOS until it was rewritten to compare against the real directory entry.

## It runs green

Actions is not enabled on this repo, so the workflow could not run on the PR. I ran it on my fork instead, [run 34134312453](https://github.com/fajarhide/anti-slop/actions/runs/34134312453):

```
success  Repo guardrails
success  Contrast table matches the formula
success  Generated core skill is in sync with antislop.md
success  Installer smoke test
```

The sync step was checked the same way. Appending a line to `antislop.md` without syncing gives `exit: 1` and names `skills/antislop/SKILL.md`.

## README

The workflow runs four things and none of them were written down, so the first a contributor hears about them is a red PR. The Contributing section now lists them, along with the one that is easy to miss: editing `antislop.md` means running `sync-skills.mjs`, because `skills/antislop/SKILL.md` is generated from it.

Every command in that block was run before it was written down, and each exits 0 on a clean tree.

## Notes

- The logic is a script, not inline YAML, so a contributor can run `node scripts/check-repo.mjs` before pushing rather than finding out from a red PR.
- No `npm ci`: nothing in `check-repo.mjs` or the smoke test imports outside node builtins, so the job needs no install step.
- `permissions: contents: read` only.
- If you want it narrower, the steps are independent. Dropping any one is a two-line delete.
## What this still does not cover

Naming it so the green tick does not promise more than it checks:

- **Checklist polarity in prose.** #9 was three checklists announcing a polarity none of their items used. That needs reading, not a regex, and I would rather leave it uncovered than ship a check that guesses.
- **The picker's prompts.** The smoke test drives the install functions, not the interactive flow.
- **Cross-platform.** ubuntu only, so the `python` and `python3` problem in #22 is invisible here by definition. A macOS and Windows matrix is the real guard for it, and belongs with that PR rather than this one.
- **The npm payload.** Nothing checks that `files` in `cli/package.json` matches what actually publishes.
- **Whether a rule is any good.** Not automatable, and not something CI should pretend to judge.
