### PR TITLE
docs: make the contributors section visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2ea44f" alt="License: MIT"></a>
   <a href="https://github.com/miqdadbadjuber/anti-slop/releases"><img src="https://img.shields.io/github/v/release/miqdadbadjuber/anti-slop?label=version&color=1f6feb" alt="Version"></a>
+  <a href="https://github.com/miqdadbadjuber/anti-slop/graphs/contributors"><img src="https://img.shields.io/github/contributors/miqdadbadjuber/anti-slop?color=8957e5" alt="Contributors"></a>
 </p>
 
 <p align="center">
@@ -164,7 +165,7 @@ Found a new AI slop pattern, a rule that missed something, or a bug in the insta
 
 Thanks to everyone who helps make antislop better.
 
-<p>
+<p align="center">
   <a href="https://github.com/miqdadbadjuber/anti-slop/graphs/contributors">
     <img src="https://contrib.rocks/image?repo=miqdadbadjuber/anti-slop" alt="antislop contributors" />
   </a>

--- a/README.md
+++ b/README.md
@@ -157,10 +157,6 @@ A folder that goes deeper into one concern (UI, copywriting, accessibility, and 
 **What are DURING and AFTER?**
 The two usage modes: DURING applies the rules while building, AFTER audits finished work. You pick one at the start of a session.
 
-## Contributing
-
-Found a new AI slop pattern, a rule that missed something, or a bug in the installer? Open an [issue](https://github.com/miqdadbadjuber/anti-slop/issues). PRs are welcome for new AI slop patterns, clarifications, or checklist items out of sync with their rule.
-
 ## Contributors
 
 Thanks to everyone who helps make antislop better.
@@ -170,6 +166,10 @@ Thanks to everyone who helps make antislop better.
     <img src="https://contrib.rocks/image?repo=miqdadbadjuber/anti-slop" alt="antislop contributors" />
   </a>
 </p>
+
+## Contributing
+
+Found a new AI slop pattern, a rule that missed something, or a bug in the installer? Open an [issue](https://github.com/miqdadbadjuber/anti-slop/issues). PRs are welcome for new AI slop patterns, clarifications, or checklist items out of sync with their rule.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ The two usage modes: DURING applies the rules while building, AFTER audits finis
 
 Found a new AI slop pattern, a rule that missed something, or a bug in the installer? Open an [issue](https://github.com/miqdadbadjuber/anti-slop/issues). PRs are welcome for new AI slop patterns, clarifications, or checklist items out of sync with their rule.
 
+## Contributors
+
+Thanks to everyone who helps make antislop better.
+
+<p>
+  <a href="https://github.com/miqdadbadjuber/anti-slop/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=miqdadbadjuber/anti-slop" alt="antislop contributors" />
+  </a>
+</p>
+
 ## License
 
 MIT: [LICENSE](LICENSE)


### PR DESCRIPTION
Adds a Contributors section, and puts a pointer to it where people actually look.

Two places:

- the badge row at the top gains a contributors count linking to the graph, next to license and version
- the avatar block sits above Contributing rather than at the very bottom, centred like every other HTML block in this README. People first, then how to join them

```markdown
## Contributors

Thanks to everyone who helps make antislop better.

<p align="center">
  <a href="https://github.com/miqdadbadjuber/anti-slop/graphs/contributors">
    <img src="https://contrib.rocks/image?repo=miqdadbadjuber/anti-slop" alt="antislop contributors" />
  </a>
</p>
```

Adapted from the usual boilerplate: "antislop" rather than "AntiSlop", since that is how the README spells it 37 times and how every plugin manifest spells it, and the alt text names this project rather than carrying another repo's word over.

Both endpoints were checked rather than assumed:

```console
$ curl -sI "https://contrib.rocks/image?repo=miqdadbadjuber/anti-slop"
HTTP/2 200
content-type: image/svg+xml

$ curl -sI "https://img.shields.io/github/contributors/miqdadbadjuber/anti-slop?color=8957e5"
HTTP/2 200
```

No fixed width on the avatar image. It is an SVG that is 132x64 today and grows as people are added, so pinning a width would make every avatar smaller the more contributors there are.

Two things you should weigh rather than me deciding for you:

- The badge reads **contributors: 2** today. That is honest and it goes up on its own, but if a small number at the top of the README is not what you want there, drop that one line and keep the section at the bottom.
- I would appear in the avatar image, and I am the one proposing it. Normal thing for a README to have, but you are the right person to decide. Close this without explanation if you would rather not.

## On merge order

I first wrote that this depends on nothing else, then test-merged it against #25 and found that was wrong: both PRs were inserting at the same anchor before `## License` and git could not tell the two additions apart.

Moving this section above `## Contributing` fixed it, and it reads better there anyway. Verified in both directions:

```console
$ git merge ci/repo-guardrails && git merge docs/contributors   # 0 conflicts
$ git merge docs/contributors && git merge ci/repo-guardrails   # 0 conflicts
```

Both orders keep both changes and pass the guardrails from #25. So there is no merge order to get right, and either PR can go in alone.
